### PR TITLE
Output error header upon failure of dotnet test of a solution 

### DIFF
--- a/_modules/echo.js
+++ b/_modules/echo.js
@@ -29,6 +29,15 @@ const echo = {
     error(message) {
         shell.echo(`${this.sdkString} ${variables.colors.red}[ERROR]${variables.colors.clear} ${message}`)
     },
+    headerError(message) {
+        this.newLine();
+        this.divider();
+        this.newLine();
+        this.error(message);
+        this.newLine();
+        this.divider();
+        this.newLine();
+    },
     message(message) {
         shell.echo(`${this.sdkString} ${message}`);
     },

--- a/cli-dotnet-test.js
+++ b/cli-dotnet-test.js
@@ -64,6 +64,7 @@ const dotnetTest = {
         dir.popd();
 
         if (result.code !== 0) {
+            echo.headerError("One or many test projects failed to compile or pass tests");
             shell.exit(result.code);
         }
     },


### PR DESCRIPTION
**Problem**
When the provided dotnet test command is run on a solution it does its best to run any/all of the test projects in the solution that it can. That includes if one of those projects doesn't compile.

<img src="https://dzwonsemrish7.cloudfront.net/items/2d2b2C1Q0g2H0x1N0I37/Image%202019-09-26%20at%2010.33.34%20AM.png?v=4fdb5937" />

**Solution**
One of the reasons we have this cli is to make up for shortcomings of other tooling. So, being we catch the exit code that is errored, thus detecting the solution did fail, we can append our own output to make up for the short comings of dotnet test

<img src="https://dzwonsemrish7.cloudfront.net/items/2I1X2y2U3K2x333k0s0c/Image%202019-09-26%20at%2010.34.42%20AM.png?v=23ca3067" />