### PR TITLE
Feature/acc 15 ef core add remove migrations

### DIFF
--- a/_modules/commands.js
+++ b/_modules/commands.js
@@ -13,10 +13,14 @@ module.exports = {
     },
     install: {
         command:     "install",
-        description: "Collection of commands related to installation and configuration of the and-cli"
+        description: "Collection of commands related to installation and configuration of the and-cli",
+    },
+    migration: {
+        command:     "migration",
+        description: "Run commands to manage Entity Framework migrations",
     },
     nuget: {
         command:     "nuget",
-        description: "Manages publishing of nuget dotnet core projects"
+        description: "Manages publishing of nuget dotnet core projects",
     },
 };

--- a/_modules/dotnet-path.js
+++ b/_modules/dotnet-path.js
@@ -131,6 +131,19 @@ const dotnetPath = {
 
         return undefined;
     },
+
+    /**
+     * Retrieves the dotnet web project file path or exits if it isn't found (memoized)
+     */
+    webProjectFilePathOrExit() {
+        const webProjectFilePath = this.webProjectFilePath();
+        if (webProjectFilePath !== undefined) {
+            return webProjectFilePath;
+        }
+
+        echo.error("Unable to find dotnet web project file");
+        shell.exit(1);
+    },
 };
 
 // #endregion Functions

--- a/_modules/dotnet-path.js
+++ b/_modules/dotnet-path.js
@@ -26,7 +26,7 @@ const solutionFilePaths = [
     "**/*.sln"
 ];
 
-// Wild-card searches used when finding the infrastructre/data dotnet core application project file. Ordered by most to least performant
+// Wild-card searches used when finding the infrastructure/data dotnet core application project file. Ordered by most to least performant
 const dataProjectFilePaths = [
     "*.csproj",
     "dotnet/*/Infrastructure/Data.SqlServer/Data.SqlServer.csproj",

--- a/_modules/dotnet-path.js
+++ b/_modules/dotnet-path.js
@@ -14,16 +14,9 @@ const upath = require("upath");
  **************************************************************************************************/
 
 let cachedCliPath;
+let cachedDataProjectPath;
 let cachedSolutionPath;
 let cachedWebProjectFilePath;
-
-// Wild-card searches used when finding the web dotnet core application project file. Ordered by most to least performant
-const webProjectFilePaths = [
-    "*.csproj",
-    "dotnet/*/Presentation/Web/Web.csproj",
-    "**/*Web.csproj",
-    "**/*.csproj"
-];
 
 // Wild-card searches used when finding the solution file. Ordered by most to least performant
 const solutionFilePaths = [
@@ -31,6 +24,23 @@ const solutionFilePaths = [
     "dotnet/*.sln",
     "dotnet/*/*.sln",
     "**/*.sln"
+];
+
+// Wild-card searches used when finding the infrastructre/data dotnet core application project file. Ordered by most to least performant
+const dataProjectFilePaths = [
+    "*.csproj",
+    "dotnet/*/Infrastructure/Data.SqlServer/Data.SqlServer.csproj",
+    "dotnet/*/Infrastructure/Data.*/Data.*.csproj",
+    "**/Data*.csproj",
+    "**/*.csproj"
+];
+
+// Wild-card searches used when finding the web dotnet core application project file. Ordered by most to least performant
+const webProjectFilePaths = [
+    "*.csproj",
+    "dotnet/*/Presentation/Web/Web.csproj",
+    "**/*Web.csproj",
+    "**/*.csproj"
 ];
 
 
@@ -66,6 +76,37 @@ const dotnetPath = {
         cachedCliPath = file.first(`${cliDebugDirPath}/**/*Cli.dll`);
 
         return cachedCliPath;
+    },
+
+    /**
+     * Retrieves the dotnet data project file path (memoized)
+     */
+    dataProjectFilePath() {
+        if (cachedDataProjectPath !== undefined) {
+            return cachedDataProjectPath;
+        }
+
+        for (var filePath of dataProjectFilePaths) {
+            cachedDataProjectPath = file.first(filePath);
+            if (cachedDataProjectPath !== undefined) {
+                return cachedDataProjectPath;
+            }
+        }
+
+        return undefined;
+    },
+
+    /**
+     * Retrieves the dotnet data project file path  or exits if it isn't found (memoized)
+     */
+    dataProjectFilePathOrExit() {
+        const dataProjectPath = this.dataProjectFilePath();
+        if (dataProjectPath !== undefined) {
+            return dataProjectPath;
+        }
+
+        echo.error("Unable to find dotnet data project file");
+        shell.exit(1);
     },
 
 

--- a/_modules/migration.js
+++ b/_modules/migration.js
@@ -20,9 +20,9 @@ const MIGRATION_MODE = {
 };
 
 const MIGRATION_COMMAND = {
-    [MIGRATION_MODE.ADD]:    " migrations add ",
-    [MIGRATION_MODE.DELETE]: " migrations remove ",
-    [MIGRATION_MODE.RUN]:    " database update ",
+    [MIGRATION_MODE.ADD]:    "migrations add",
+    [MIGRATION_MODE.DELETE]: "migrations remove",
+    [MIGRATION_MODE.RUN]:    "database update",
 };
 
 // #endregion Constants
@@ -33,9 +33,9 @@ const MIGRATION_COMMAND = {
 
 // #region Variables
 
-let _startupProjectDir = dotnetPath.webProjectFilePath();
-let _migrationName     = null;
-let _mode              = null;
+const _startupProjectDir = dotnetPath.webProjectFilePath();
+let   _migrationName     = null;
+let   _mode              = null;
 
 // #endregion Variables
 
@@ -52,14 +52,14 @@ const migration = {
             case MIGRATION_MODE.ADD:
             case MIGRATION_MODE.DELETE:
             case MIGRATION_MODE.RUN:
-                baseCmd += MIGRATION_COMMAND[mode];
+                baseCmd = `${baseCmd} ${MIGRATION_COMMAND[mode]}`;
                 break;
             default:
                 echo.error(`Invalid mode specified. Available options are: ${Object.keys(MIGRATION_MODE)}`);
                 shell.exit(1);
                 break;
         }
-        return baseCmd + `${migrationName} --startup-project ${startupProjectDir} --verbose`;
+        return  `${baseCmd} ${migrationName} --startup-project ${startupProjectDir} --verbose`;
     },
     description(mode) {
         switch(mode) {
@@ -69,7 +69,6 @@ const migration = {
                 return `Delete most recent entity framework migration (via ${this.cmd(mode, "", _startupProjectDir)})`
             case MIGRATION_MODE.RUN:
                 return `Run (or revert) entity framework migration (via ${this.cmd(mode, "<migration name>", _startupProjectDir)})`
-                break;
             default:
                 echo.error(`Invalid mode specified. Available options are: ${Object.keys(MIGRATION_MODE)}`);
                 shell.exit(1);
@@ -77,13 +76,13 @@ const migration = {
         }
     },
     migrationName(migrationName = null) {
-        if (migrationName !== null && migrationName !== _migrationName) {
+        if (migrationName !== null) {
             _migrationName = migrationName;
         }
         return this;
     },
     mode(mode = null) {
-        if (mode !== null && mode !== _mode) {
+        if (mode !== null) {
             _mode = mode;
         }
         return this;
@@ -114,7 +113,7 @@ const migration = {
 
         if (result.code !== 0) {
             echo.error(`Error running migration command: ${result}`);
-            shell.exit(1);
+            shell.exit(result.code);
         }
 
         dir.popd();

--- a/_modules/migration.js
+++ b/_modules/migration.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+const dir        = require("./dir");
+const dotnetPath = require("./dotnet-path");
+const echo       = require("./echo");
+const shell      = require("shelljs");
+const upath = require("upath");
+
+
+// #region Constants
+
+const MIGRATION_MODE = {
+    ADD:    "ADD",
+    DELETE: "DELETE",
+    RUN:    "RUN",
+};
+
+const MIGRATION_COMMAND = {
+    [MIGRATION_MODE.ADD]:    " migrations add ",
+    [MIGRATION_MODE.DELETE]: " migrations remove ",
+    [MIGRATION_MODE.RUN]:    " database update ",
+};
+
+// #endregion Constants
+
+// #region Variables
+
+let _migrationName = null;
+let _mode          = null;
+
+// #endregion Variables
+
+const migration = {
+    cmd(mode, migrationName, startupProjectDir) {
+        let baseCmd = "dotnet ef";
+        switch(mode) {
+            case MIGRATION_MODE.ADD:
+            case MIGRATION_MODE.DELETE:
+            case MIGRATION_MODE.RUN:
+                baseCmd += MIGRATION_COMMAND[mode];
+                break;
+            default:
+                echo.error(`Invalid mode specified. Available options are: `);
+                Object.keys(MIGRATION_MODE).map((mode) => echo.message(mode.toString()));
+                shell.exit(1);
+                break;
+        }
+        return baseCmd + `${migrationName} --startup-project ${startupProjectDir} --verbose`;
+    },
+    descriptionCreate() {
+        return "Create new entity framework migration";
+    },
+    descriptionDelete() {
+        return "Delete most recent entity framework migration";
+    },
+    descriptionRun() {
+        return "Run (or revert) entity framework migration";
+    },
+    migrationName(migrationName = null) {
+        if (migrationName !== null && migrationName !== _migrationName) {
+            _migrationName = migrationName;
+        }
+        return this;
+    },
+    mode(mode = null) {
+        if (mode !== null && mode !== _mode) {
+            _mode = mode;
+        }
+        return this;
+    },
+    modes() {
+        return MIGRATION_MODE;
+    },
+    run() {
+        if ((_mode === MIGRATION_MODE.ADD || _mode === MIGRATION_MODE.RUN) && _migrationName == null) {
+            echo.error("Migration name is required, and can only be one word.");
+            shell.exit(1);
+        }
+
+        dotnetPath.webProjectFilePathOrExit();
+        const webProjectFileDir = upath.join(shell.pwd(), dotnetPath.webProjectFileDir());
+
+        console.log("webProjectFileDir", webProjectFileDir);
+        let migrationCmd = this.cmd(_mode, _migrationName, webProjectFileDir);
+
+        echo.message(`Running EF migration command... (via ${migrationCmd})`);
+
+        dir.pushd(webProjectFileDir);
+
+        const result = shell.exec(migrationCmd);
+
+        if (result.code !== 0) {
+            echo.error(`Error running migration command: ${result}`);
+            shell.exit(1);
+        }
+
+        dir.popd();
+
+        echo.success("Finished running migration command. Remember to double check that the migration looks right before committing.");
+    },
+}
+
+// #endregion Migration commands
+
+module.exports = migration;

--- a/_modules/migration.js
+++ b/_modules/migration.js
@@ -3,8 +3,9 @@
 const dir        = require("./dir");
 const dotnetPath = require("./dotnet-path");
 const echo       = require("./echo");
+const path       = require("path");
 const shell      = require("shelljs");
-const upath = require("upath");
+const upath      = require("upath");
 
 
 // #region Constants
@@ -40,8 +41,7 @@ const migration = {
                 baseCmd += MIGRATION_COMMAND[mode];
                 break;
             default:
-                echo.error(`Invalid mode specified. Available options are: `);
-                Object.keys(MIGRATION_MODE).map((mode) => echo.message(mode.toString()));
+                echo.error(`Invalid mode specified. Available options are: ${Object.keys(MIGRATION_MODE)}`);
                 shell.exit(1);
                 break;
         }
@@ -72,7 +72,8 @@ const migration = {
         return MIGRATION_MODE;
     },
     run() {
-        if ((_mode === MIGRATION_MODE.ADD || _mode === MIGRATION_MODE.RUN) && _migrationName == null) {
+        if ((_mode === MIGRATION_MODE.ADD || _mode === MIGRATION_MODE.RUN) &&
+            (_migrationName === null || _migrationName.length !== 1)) {
             echo.error("Migration name is required, and can only be one word.");
             shell.exit(1);
         }
@@ -80,12 +81,14 @@ const migration = {
         dotnetPath.webProjectFilePathOrExit();
         const webProjectFileDir = upath.join(shell.pwd(), dotnetPath.webProjectFileDir());
 
-        console.log("webProjectFileDir", webProjectFileDir);
-        let migrationCmd = this.cmd(_mode, _migrationName, webProjectFileDir);
+        const dataProjectFilePath = dotnetPath.dataProjectFilePathOrExit();
+        const dataProjectDir      = path.dirname(dataProjectFilePath);
+
+        const migrationCmd = this.cmd(_mode, _migrationName, webProjectFileDir);
 
         echo.message(`Running EF migration command... (via ${migrationCmd})`);
 
-        dir.pushd(webProjectFileDir);
+        dir.pushd(dataProjectDir);
 
         const result = shell.exec(migrationCmd);
 

--- a/_modules/migration.js
+++ b/_modules/migration.js
@@ -7,6 +7,9 @@ const path       = require("path");
 const shell      = require("shelljs");
 const upath      = require("upath");
 
+/**************************************************************************************************
+ * Constants
+ **************************************************************************************************/
 
 // #region Constants
 
@@ -24,12 +27,23 @@ const MIGRATION_COMMAND = {
 
 // #endregion Constants
 
+/**************************************************************************************************
+ * Variables
+ **************************************************************************************************/
+
 // #region Variables
 
-let _migrationName = null;
-let _mode          = null;
+let _startupProjectDir = dotnetPath.webProjectFilePath();
+let _migrationName     = null;
+let _mode              = null;
 
 // #endregion Variables
+
+/**************************************************************************************************
+ * Functions
+ **************************************************************************************************/
+
+// #region Functions
 
 const migration = {
     cmd(mode, migrationName, startupProjectDir) {
@@ -47,14 +61,20 @@ const migration = {
         }
         return baseCmd + `${migrationName} --startup-project ${startupProjectDir} --verbose`;
     },
-    descriptionCreate() {
-        return "Create new entity framework migration";
-    },
-    descriptionDelete() {
-        return "Delete most recent entity framework migration";
-    },
-    descriptionRun() {
-        return "Run (or revert) entity framework migration";
+    description(mode) {
+        switch(mode) {
+            case MIGRATION_MODE.ADD:
+                return `Create new entity framework migration (via ${this.cmd(mode, "<migration name>", _startupProjectDir)})`;
+            case MIGRATION_MODE.DELETE:
+                return `Delete most recent entity framework migration (via ${this.cmd(mode, "", _startupProjectDir)})`
+            case MIGRATION_MODE.RUN:
+                return `Run (or revert) entity framework migration (via ${this.cmd(mode, "<migration name>", _startupProjectDir)})`
+                break;
+            default:
+                echo.error(`Invalid mode specified. Available options are: ${Object.keys(MIGRATION_MODE)}`);
+                shell.exit(1);
+                break;
+        }
     },
     migrationName(migrationName = null) {
         if (migrationName !== null && migrationName !== _migrationName) {
@@ -103,6 +123,10 @@ const migration = {
     },
 }
 
-// #endregion Migration commands
+// #endregion Functions
+
+/**************************************************************************************************
+ * Exports
+ **************************************************************************************************/
 
 module.exports = migration;

--- a/cli-migration.js
+++ b/cli-migration.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const commands  = require("./_modules/commands");
+const program   = require("commander");
+const migration = require("./_modules/migration");
+const modes     = migration.modes();
+
+// #endregion Migration commands
+
+// #region Entrypoint / Command router
+
+program
+    .usage("option")
+    .description(commands.migration.description)
+    .option("-a, --add",                  migration.descriptionCreate())
+    .option("-d, --delete",               migration.descriptionDelete())
+    .option("-r, --run",                  migration.descriptionRun())
+    .parse(process.argv);
+
+if (program.add) {
+    migration
+        .mode(modes.ADD)
+        .migrationName(program.args)
+        .run();
+}
+
+if (program.delete) {
+    migration
+        .mode(modes.DELETE)
+        .migrationName(program.args)
+        .run();
+}
+
+if (program.run) {
+    migration
+        .mode(modes.RUN)
+        .migrationName(program.args)
+        .run();
+}
+
+if (process.argv.slice(2).length === 0) { program.help();                     }
+
+// #endregion Entrypoint / Command router

--- a/cli-migration.js
+++ b/cli-migration.js
@@ -1,20 +1,31 @@
 #!/usr/bin/env node
 
+/**************************************************************************************************
+ * Imports
+ **************************************************************************************************/
+
 const commands  = require("./_modules/commands");
 const program   = require("commander");
 const migration = require("./_modules/migration");
-const modes     = migration.modes();
 
-// #endregion Migration commands
+/**************************************************************************************************
+ * Variables
+ **************************************************************************************************/
+
+const modes = migration.modes();
+
+/**************************************************************************************************
+ * Entrypoint / Command router
+ **************************************************************************************************/
 
 // #region Entrypoint / Command router
 
 program
     .usage("option")
     .description(commands.migration.description)
-    .option("-a, --add",                  migration.descriptionCreate())
-    .option("-d, --delete",               migration.descriptionDelete())
-    .option("-r, --run",                  migration.descriptionRun())
+    .option("-a, --add",     migration.description(modes.ADD))
+    .option("-d, --delete",  migration.description(modes.DELETE))
+    .option("-r, --run",     migration.description(modes.RUN))
     .parse(process.argv);
 
 if (program.add) {
@@ -38,6 +49,6 @@ if (program.run) {
         .run();
 }
 
-if (process.argv.slice(2).length === 0) { program.help();                     }
+if (process.argv.slice(2).length === 0) { program.help(); }
 
 // #endregion Entrypoint / Command router


### PR DESCRIPTION
Added 'migration' command for managing EF Core database migrations. If anyone has suggestions on making the 'data project' file path searching more generic (or even a better way to interface with `dotnet ef`) I am more than welcome to hearing them!

Addresses issue #15 