### PR TITLE
Issue #33 - Force installation of compatible AWS CLI and AWS EB CLIs

### DIFF
--- a/cli-deploy-aws-beanstalk.js
+++ b/cli-deploy-aws-beanstalk.js
@@ -105,7 +105,8 @@ const deployAwsBeanstalk = {
         if (!shell.which("eb")) {
             echo.message("AWS EB CLI not found. Installing via PIP...");
 
-            if (shell.exec("pip install awsebcli").code !== 0) {
+            // Unfortunately we must lock down our awscli and awsebcli versions so they use compatible dependencies https://github.com/aws/aws-cli/issues/3550
+            if (shell.exec("pip install awsebcli==3.14.4").code !== 0) {
                 echo.error("Failed to install eb cli via pip");
                 shell.exit(1);
             }

--- a/cli-deploy-aws-s3.js
+++ b/cli-deploy-aws-s3.js
@@ -100,7 +100,8 @@ const deployAwsS3 = {
         if (!shell.which("aws")) {
             echo.message("AWS CLI not found. Installing via PIP...");
 
-            if (shell.exec("pip install awscli").code !== 0) {
+            // Unfortunately we must lock down our awscli and awsebcli versions so they use compatible dependencies https://github.com/aws/aws-cli/issues/3550
+            if (shell.exec("pip install awscli==1.16.9").code !== 0) {
                 echo.error("Failed to install aws cli via pip");
                 shell.exit(1);
             }


### PR DESCRIPTION
Lock awscli and awsebcli to compatible version numbers to fix issue #33 