### PR TITLE
Issue #35 - Increase default awsebcli timeout from 10 to 20 and accept override

### DIFF
--- a/cli-deploy-aws-beanstalk.js
+++ b/cli-deploy-aws-beanstalk.js
@@ -21,6 +21,7 @@ const zip           = require("./_modules/zip");
  **************************************************************************************************/
 
 const pythonInstallerUrl = "https://www.python.org/ftp/python/3.7.4/python-3.7.4-amd64.exe";
+let   timeout            = 20; // Default AWSEBCLI command timeout in minutes
 
 
 /**************************************************************************************************
@@ -39,6 +40,11 @@ const deployAwsBeanstalk = {
     async run() {
         // Check system requirements
         this.validateOrExit();
+
+        // Handling incoming arguments
+        if (program.timeout) {
+            timeout = program.timeout;
+        }
 
         let projectDir = "";
 
@@ -77,7 +83,7 @@ const deployAwsBeanstalk = {
 
         // Call EB deploy
         echo.message("Deploying to AWS beanstalk. Check AWS console for realtime output. This could take a few minutes...");
-        if (shell.exec(this.cmds.deploy).code !== 0) {
+        if (shell.exec(this.cmds.deploy + ` --timeout ${timeout}`).code !== 0) {
             echo.error(" - Failed to deploy to AWS beanstalk");
             shell.exit(1);
         }
@@ -130,7 +136,8 @@ const deployAwsBeanstalk = {
 program
     .usage("option")
     .description(deployAwsBeanstalk.description())
-    .option("--dotnet", "Deploy dotnet core application via beanstalk")
+    .option("--dotnet",  "Deploy dotnet core application via beanstalk")
+    .option("--timeout", `Optional elastic beanstalk deploy timeout. Default is ${timeout} minutes. When exceeded, exits with error`)
     .parse(process.argv);
 
 // #endregion Entrypoint / Command router


### PR DESCRIPTION
To fix issue #35 we make the default timeout from our deploy aws-beanstalk command use a default of 20 minutes (increasing the default of 10 minutes from EB). Additionally users of the command can provided a `--timeout` flag to set it in their project