### PR TITLE
Feature/cli 24 update nuget pkg in sln

### DIFF
--- a/_modules/user-prompt.js
+++ b/_modules/user-prompt.js
@@ -47,7 +47,7 @@ const prompt = {
     async confirmOrExit(question, exitStatus = 0) {
         const prompt = this.getPrompt();
 
-        const answer = await prompt.questionAsync(`${question} ${formatters.yellow("(y/n)")}: `);
+        const answer = await prompt.questionAsync(`${question} ${formatters.yellow("(y/N)")}: `);
         if (!answer.match(/[yY]/)) {
             shell.exit(exitStatus);
         }

--- a/_modules/user-prompt.js
+++ b/_modules/user-prompt.js
@@ -1,0 +1,64 @@
+/**************************************************************************************************
+ * Imports
+ **************************************************************************************************/
+
+const formatters = require("./formatters");
+const readline   = require("readline-promise").default;
+const shell      = require("shelljs");
+
+/**************************************************************************************************
+ * Variables
+ **************************************************************************************************/
+
+let cachedPrompt;
+
+/**************************************************************************************************
+ * Functions
+ **************************************************************************************************/
+
+// #region Prompt commands
+
+const prompt = {
+
+    /**
+     * Creates and returns a readline interface for accessing stdin/stdout. Returns a cached version if already
+     * created.
+     *
+     */
+    getPrompt() {
+        if (cachedPrompt !== undefined) {
+            return cachedPrompt;
+        }
+
+        cachedPrompt = readline.createInterface({
+            input:  process.stdin,
+            output: process.stdout,
+        });
+
+        return cachedPrompt;
+    },
+
+    /**
+     * Prompts the user for confirmation, and exits if the user does not type y or Y.
+     *
+     * @param {*} question Question to pose to the user
+     * @param {number} [exitStatus=0] Exit status to pass to shelljs if confirmation unsccessful
+     */
+    async confirmOrExit(question, exitStatus = 0) {
+        const prompt = this.getPrompt();
+
+        const answer = await prompt.questionAsync(`${question} ${formatters.yellow("(y/n)")}: `);
+        if (!answer.match(/[yY]/)) {
+            shell.exit(exitStatus);
+        }
+    }
+}
+
+// #endregion Prompt commands
+
+
+/**************************************************************************************************
+ * Exports
+ **************************************************************************************************/
+
+module.exports = prompt;

--- a/_modules/variables.js
+++ b/_modules/variables.js
@@ -1,10 +1,10 @@
 exports.colors = {
-    clear:  "\033[0m",
-    green:  "\033[0;32m",
-    purple: "\033[1;35m",
-    red:    "\033[0;31m",
-    white:  "\033[1;37m",
-    yellow: "\033[1;33m"
+    clear:  "\x1b[0m",
+    green:  "\x1b[0;32m",
+    purple: "\x1b[1;35m",
+    red:    "\x1b[31m",
+    white:  "\x1b[1;37m",
+    yellow: "\x1b[1;33m"
 };
 
 exports.symbols = {

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -169,9 +169,9 @@ const nugetUpgrade = {
         this.packageName = packageName;
     },
     validatePackageVersion(packageVersion) {
-        if (!packageVersion.match(versionRegexPattern)) {
+        if (packageVersion == null || !packageVersion.match(versionRegexPattern)) {
             echo.error(ERROR_INVALID_VERSION_STRING);
-            shell.exit(1);
+            shell.exit(-1);
         }
 
         this.packageVersion = packageVersion;

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -117,7 +117,7 @@ const nugetUpgrade = {
         const matchingProjects = grepResult.stdout.split("\n").filter((result) => result.trim() !== "");
         if (matchingProjects.length === 0) {
             echo.message(`No projects found with package '${this.packageName}'. Exiting.`);
-            shell.exit(-1);
+            shell.exit(1);
         }
 
         return matchingProjects;
@@ -171,7 +171,7 @@ const nugetUpgrade = {
     validatePackageName(packageName) {
         if (packageName == null || packageName.trim() === "") {
             echo.error("Please enter a valid package name.");
-            shell.exit(-1);
+            shell.exit(1);
         }
 
         return packageName.trim();
@@ -179,7 +179,7 @@ const nugetUpgrade = {
     validatePackageVersion(packageVersion) {
         if (packageVersion == null || !packageVersion.match(versionRegexPattern)) {
             echo.error(ERROR_INVALID_VERSION_STRING);
-            shell.exit(-1);
+            shell.exit(1);
         }
 
         return packageVersion;

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -161,7 +161,7 @@ const nugetUpgrade = {
         this.promptForConfirmation();
     },
     validatePackageName(packageName) {
-        if (packageName.trim() === "") {
+        if (packageName == null || packageName.trim() === "") {
             echo.error("Please enter a valid package name.");
             shell.exit(-1);
         }
@@ -201,3 +201,5 @@ if (program.upgrade) { nugetUpgrade.run(); }
 if (process.argv.slice(2).length === 0) { program.help(); }
 
 // #endregion Entrypoint / Command router
+
+exports.nugetUpgrade = nugetUpgrade;

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -26,16 +26,6 @@ const ERROR_INVALID_VERSION_STRING = "Invalid package version string (see https:
 const ERROR_READING_CSPROJ_FILES   = "There was an error reading csproj files.";
 
 /**************************************************************************************************
- * Helper functions
- **************************************************************************************************/
-
-const _isNonEmptyString = (value) =>
-    value !== undefined &&
-    value !== null &&
-    typeof value === "string" &&
-    value.length > 1;
-
-/**************************************************************************************************
  * Commands
  **************************************************************************************************/
 

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -7,6 +7,7 @@
 const commands      = require("./_modules/commands");
 const dotnetPath    = require("./_modules/dotnet-path");
 const echo          = require("./_modules/echo");
+const formatters    = require("./_modules/formatters");
 const program       = require("commander");
 const shell         = require("shelljs");
 
@@ -20,6 +21,7 @@ const nugetUrl = "https://api.nuget.org/v3/index.json";
 // Semver regex pattern for validating version number (see https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)
 const versionRegexPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
+const ERROR_INVALID_VERSION_STRING = "Invalid package version string (see https://docs.microsoft.com/en-us/nuget/concepts/package-versioning)";
 
 /**************************************************************************************************
  * Commands
@@ -39,7 +41,7 @@ const nugetPublish = {
         const publishVersion = program.publish;
 
         if (!publishVersion.match(versionRegexPattern)) {
-            echo.error("Invalid publish version string (see https://docs.microsoft.com/en-us/nuget/concepts/package-versioning)");
+            echo.error(ERROR_INVALID_VERSION_STRING);
             shell.exit(1);
             return;
         }
@@ -84,6 +86,38 @@ const nugetPublish = {
     },
 }
 
+const nugetUpgrade = {
+    description() {
+        return
+    },
+    description: {
+        upgrade: "Upgrades a specified NuGet package for all projects in a solution.",
+        version: `${formatters.red("(Required with --upgrade)")} Specifies the version of the package to upgrade to.`
+    },
+    run() {
+        const packageName    = program.upgrade;
+        const packageVersion = program.version;
+
+        if (!packageVersion.match(versionRegexPattern)) {
+            echo.error(ERROR_INVALID_VERSION_STRING);
+            shell.exit(1);
+            return;
+        }
+
+        echo.message(`Upgrading package '${packageName}' to version ${packageVersion}...`);
+
+        const grepResult       = shell.grep("-l", packageName, shell.ls("**/*.csproj"));
+        const matchingProjects = grepResult.stdout.split("\n").filter((result) => result.trim() !== "");
+
+        if (matchingProjects.length === 0) {
+            echo.message(`No projects found with package '${packageName}'. Exiting.`);
+            shell.exit(0);
+        }
+
+        echo.message(`${formatters.red(matchingProjects.length)} projects found with package '${packageName}'. Continue? (y/n)`);
+    }
+}
+
 // #endregion NuGet commands
 
 
@@ -97,9 +131,19 @@ program
     .usage("option(s)")
     .description(commands.nuget.description)
     .option("-p, --publish <version>", nugetPublish.description())
+    .option("-u, --upgrade <package>", nugetUpgrade.description.upgrade)
+    .option("-v, --version <version>", nugetUpgrade.description.version)
     .parse(process.argv);
 
-if (program.publish) { nugetPublish.run(); }
+if (program.publish)                    { nugetPublish.run(); }
+if (program.upgrade && program.version) { nugetUpgrade.run(); }
+
+// User-friendly error checking to make sure upgrade & version flags are used together
+if ((program.upgrade && !program.version) ||
+    (!program.upgrade && program.version)) {
+        echo.error("-u or --upgrade must be used in conjunction with -v or --version");
+        program.help();
+}
 
 // If no options are passed in, output help
 if (process.argv.slice(2).length === 0) { program.help(); }

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -90,7 +90,7 @@ const nugetPublish = {
 
 const nugetUpgrade = {
     description() {
-        return "Upgrades a specified NuGet package for all projects in a solution.";
+        return "Prompts the user to specify a NuGet package to upgrade for all projects in a solution.";
     },
     run() {
         const prompt = readline.createInterface({
@@ -178,7 +178,7 @@ program
     .usage("option(s)")
     .description(commands.nuget.description)
     .option("-p, --publish <version>", nugetPublish.description())
-    .option("-u, --upgrade [package]", nugetUpgrade.description())
+    .option("-u, --upgrade", nugetUpgrade.description())
     .parse(process.argv);
 
 if (program.publish) { nugetPublish.run(); }

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -160,6 +160,13 @@ const nugetUpgrade = {
                         shell.exit(0);
                     }
 
+                    const sedResult = shell.sed("-i", `(<PackageReference[ ]*Include[ ]*=[ ]*\"${packageName}\"[ ]*Version[ ]*=[ ]*\")([0-9]+.[0-9]+.[0-9]+)`, `$1${packageVersion}`, matchingProjects);
+                    if (sedResult.code !== 0) {
+                        echo.error(`There was an error updating csproj files: ${sedResult}`);
+                        shell.exit(sedResult.code);
+                    }
+
+                    echo.success(`Successfully updated '${packageName}' to version ${packageVersion}. Please check your git status before committing.`);
                     shell.exit(0);
                 });
             });

--- a/cli-nuget.js
+++ b/cli-nuget.js
@@ -103,13 +103,7 @@ const nugetUpgrade = {
             shell.exit(findResult.code);
         }
 
-        const csprojFiles = findResult.filter((file) => file.trim() !== "");
-        if (csprojFiles.length === 0) {
-            echo.error("No csproj files could be found. Please check the directory you're in.");
-            shell.exit(-1);
-        }
-
-        return csprojFiles;
+        return findResult;
     },
     getCsprojFilesContainingPackage(csprojFiles) {
         echo.message(`Looking for packages matching '${this.packageName}'...`);

--- a/cli-nuget.test.js
+++ b/cli-nuget.test.js
@@ -24,12 +24,12 @@ describe("nugetUpgrade", () => {
 
     describe("validatePackageName()", () => {
         test.each`
-            input
+            packageName
             ${undefined}
             ${null}
             ${""}
             ${" "}
-        `("when given '$input' as a package name, it calls shell.exit", ({ packageName }) => {
+        `("when given '$packageName' as a package name, it calls shell.exit", ({ packageName }) => {
             // Arrange & Act
             sut.validatePackageName(packageName);
 
@@ -40,6 +40,40 @@ describe("nugetUpgrade", () => {
         test("when given a string with >= 1 characters, it does not call shell.exit", () => {
             // Arrange & Act
             sut.validatePackageName("AutoMapper");
+
+            // Assert
+            expect(shellExitSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("validatePackageVersion()", () => {
+        test.each`
+            packageVersion
+            ${undefined}
+            ${null}
+            ${""}
+            ${" "}
+            ${"1"}
+            ${"1.0"}
+            ${"1.0.x"}
+            ${"red"}
+        `("when given '$packageVersion' as a package version, it calls shell.exit", ({ packageVersion }) => {
+            // Arrange & Act
+            sut.validatePackageVersion(packageVersion);
+
+            // Assert
+            expect(shellExitSpy).toHaveBeenCalledWith(-1);
+        });
+
+        test.each`
+            packageVersion
+            ${"1.0.1"}
+            ${"6.11.1231"}
+            ${"4.3.1-rc"}
+            ${"2.2.44-beta1"}
+        `("when given a valid semver '$packageVersion', it does not call shell.exit", ({ packageVersion }) => {
+            // Arrange & Act
+            sut.validatePackageVersion(packageVersion);
 
             // Assert
             expect(shellExitSpy).not.toHaveBeenCalled();

--- a/cli-nuget.test.js
+++ b/cli-nuget.test.js
@@ -1,0 +1,6 @@
+
+describe("nuget", () => {
+    test("when x, it returns y", () => {
+        expect(true).toBe(true);
+    })
+})

--- a/cli-nuget.test.js
+++ b/cli-nuget.test.js
@@ -19,6 +19,40 @@ describe("nugetUpgrade", () => {
     });
 
     /**************************************************************************************************
+     * replacePackageVersion()
+     **************************************************************************************************/
+
+    describe("replacePackageVersion()", () => {
+        test("when shell.sed returns non-zero exit code, it calls shell.exit with that code", () => {
+            // Arrange
+            const shellSedMock = jest.fn().mockImplementation(() => {
+                return { code: -1 };
+            });
+            shell.sed = shellSedMock;
+
+            // Act
+            sut.replacePackageVersion();
+
+            // Assert
+            expect(shell.exit).toHaveBeenCalledWith(-1);
+        });
+
+        test("when shell.sed returns zero exit code, it calls shell.exit code 0", () => {
+            // Arrange
+            const shellSedMock = jest.fn().mockImplementation(() => {
+                return { code: 0 };
+            });
+            shell.sed = shellSedMock;
+
+            // Act
+            sut.replacePackageVersion();
+
+            // Assert
+            expect(shell.exit).toHaveBeenCalledWith(0);
+        });
+    });
+
+    /**************************************************************************************************
      * validatePackageName()
      **************************************************************************************************/
 

--- a/cli-nuget.test.js
+++ b/cli-nuget.test.js
@@ -97,8 +97,6 @@ describe("nugetUpgrade", () => {
     describe("validatePackageVersion()", () => {
         test.each`
             packageVersion
-            ${undefined}
-            ${null}
             ${""}
             ${" "}
             ${"1"}

--- a/cli-nuget.test.js
+++ b/cli-nuget.test.js
@@ -11,11 +11,31 @@ const shell     = require("shelljs");
 const sut = cli_nuget.nugetUpgrade;
 
 describe("nugetUpgrade", () => {
+    const mockFnExitStatus = (code) => jest.fn().mockImplementation(() => {
+        return { code };
+    });
 
     let shellExitSpy;
 
     beforeEach(() => {
         shellExitSpy = jest.spyOn(shell, "exit").mockImplementation(() => {});
+    });
+
+    /**************************************************************************************************
+     * findCsprojFiles()
+     **************************************************************************************************/
+
+    describe("findCsprojFiles()", () => {
+        test("when shell.find returns non-zero exit code, it calls shell.exit with that code", () => {
+            // Arrange
+            shell.find = mockFnExitStatus(-1);
+
+            // Act
+            sut.findCsprojFiles();
+
+            // Assert
+            expect(shell.exit).toHaveBeenCalledWith(-1);
+        });
     });
 
     /**************************************************************************************************
@@ -25,10 +45,7 @@ describe("nugetUpgrade", () => {
     describe("replacePackageVersion()", () => {
         test("when shell.sed returns non-zero exit code, it calls shell.exit with that code", () => {
             // Arrange
-            const shellSedMock = jest.fn().mockImplementation(() => {
-                return { code: -1 };
-            });
-            shell.sed = shellSedMock;
+            shell.sed = mockFnExitStatus(-1);
 
             // Act
             sut.replacePackageVersion();
@@ -37,12 +54,9 @@ describe("nugetUpgrade", () => {
             expect(shell.exit).toHaveBeenCalledWith(-1);
         });
 
-        test("when shell.sed returns zero exit code, it calls shell.exit code 0", () => {
+        test("when shell.sed returns zero exit code, it calls shell.exit with code zero", () => {
             // Arrange
-            const shellSedMock = jest.fn().mockImplementation(() => {
-                return { code: 0 };
-            });
-            shell.sed = shellSedMock;
+            shell.sed = mockFnExitStatus(0);
 
             // Act
             sut.replacePackageVersion();
@@ -63,7 +77,7 @@ describe("nugetUpgrade", () => {
             ${null}
             ${""}
             ${" "}
-        `("when given '$packageName' as a package name, it calls shell.exit", ({ packageName }) => {
+        `("when given '$packageName' as a package name, it calls shell.exit with non-zero code", ({ packageName }) => {
             // Arrange & Act
             sut.validatePackageName(packageName);
 

--- a/cli-nuget.test.js
+++ b/cli-nuget.test.js
@@ -1,6 +1,48 @@
+/**************************************************************************************************
+ * Imports
+ **************************************************************************************************/
+const cli_nuget = require("./cli-nuget");
+const shell     = require("shelljs");
 
-describe("nuget", () => {
-    test("when x, it returns y", () => {
-        expect(true).toBe(true);
-    })
-})
+
+/**************************************************************************************************
+ * Variables
+ **************************************************************************************************/
+const sut = cli_nuget.nugetUpgrade;
+
+describe("nugetUpgrade", () => {
+
+    let shellExitSpy;
+
+    beforeEach(() => {
+        shellExitSpy = jest.spyOn(shell, "exit").mockImplementation(() => {});
+    });
+
+    /**************************************************************************************************
+     * validatePackageName()
+     **************************************************************************************************/
+
+    describe("validatePackageName()", () => {
+        test.each`
+            input
+            ${undefined}
+            ${null}
+            ${""}
+            ${" "}
+        `("when given '$input' as a package name, it calls shell.exit", ({ packageName }) => {
+            // Arrange & Act
+            sut.validatePackageName(packageName);
+
+            // Assert
+            expect(shellExitSpy).toHaveBeenCalledWith(-1);
+        });
+
+        test("when given a string with >= 1 characters, it does not call shell.exit", () => {
+            // Arrange & Act
+            sut.validatePackageName("AutoMapper");
+
+            // Assert
+            expect(shellExitSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/cli-nuget.test.js
+++ b/cli-nuget.test.js
@@ -28,13 +28,13 @@ describe("nugetUpgrade", () => {
     describe("findCsprojFiles()", () => {
         test("when shell.find returns non-zero exit code, it calls shell.exit with that code", () => {
             // Arrange
-            shell.find = mockShellFn(-1);
+            shell.find = mockShellFn(1);
 
             // Act
             sut.findCsprojFiles();
 
             // Assert
-            expect(shell.exit).toHaveBeenCalledWith(-1);
+            expect(shell.exit).toHaveBeenCalledWith(1);
         });
     });
 
@@ -54,7 +54,7 @@ describe("nugetUpgrade", () => {
             expect(shell.exit).toHaveBeenCalledWith(100);
         });
 
-        test("when shell.grep returns zero exit code but no files with the package are found, it calls shell.exit with -1 exit code", () => {
+        test("when shell.grep returns zero exit code but no files with the package are found, it calls shell.exit with 1 exit code", () => {
             // Arrange
             shell.grep = mockShellFn(0);
 
@@ -62,7 +62,7 @@ describe("nugetUpgrade", () => {
             sut.getCsprojFilesContainingPackage([]);
 
             // Assert
-            expect(shell.exit).toHaveBeenCalledWith(-1);
+            expect(shell.exit).toHaveBeenCalledWith(1);
         });
     });
 
@@ -73,13 +73,13 @@ describe("nugetUpgrade", () => {
     describe("replacePackageVersion()", () => {
         test("when shell.sed returns non-zero exit code, it calls shell.exit with that code", () => {
             // Arrange
-            shell.sed = mockShellFn(-1);
+            shell.sed = mockShellFn(1);
 
             // Act
             sut.replacePackageVersion();
 
             // Assert
-            expect(shell.exit).toHaveBeenCalledWith(-1);
+            expect(shell.exit).toHaveBeenCalledWith(1);
         });
 
         test("when shell.sed returns zero exit code, it calls shell.exit with code zero", () => {
@@ -108,7 +108,7 @@ describe("nugetUpgrade", () => {
             sut.validatePackageName(packageName);
 
             // Assert
-            expect(shellExitSpy).toHaveBeenCalledWith(-1);
+            expect(shellExitSpy).toHaveBeenCalledWith(1);
         });
 
         test("when given a string with >= 1 characters, it does not call shell.exit", () => {
@@ -134,7 +134,7 @@ describe("nugetUpgrade", () => {
             sut.validatePackageVersion(packageVersion);
 
             // Assert
-            expect(shellExitSpy).toHaveBeenCalledWith(-1);
+            expect(shellExitSpy).toHaveBeenCalledWith(1);
         });
 
         test.each`

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,13 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
+  automock: true,
   clearMocks: true,
   coverageDirectory: "coverage",
-  testEnvironment: "node"
+  testEnvironment: "node",
+  unmockedModulePathPatterns: [
+    "./cli-*",   // Don't mock the commands that we're testing
+    "commander", // Throws a TypeError for description() method
+    "glob",      // Throws a TypeError for 'inflight' and 'once' package dependencies
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "and-cli",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4266,6 +4266,11 @@
         "isarray": "0.0.1",
         "string_decoder": "~0.10.x"
       }
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "realpath-native": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4267,10 +4267,10 @@
         "string_decoder": "~0.10.x"
       }
     },
-    "readline-sync": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
-      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
+    "readline-promise": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/readline-promise/-/readline-promise-1.0.4.tgz",
+      "integrity": "sha512-b6fycDK7CZWpVXbTl8qnW2jovXPduWKpZGyVZbjK/V4A9iiTU4gur+JEkjjgGKLiDZOftkRCT/dxGLG6hR9HyA=="
     },
     "realpath-native": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "archiver": "3.1.1",
     "chalk": "^2.4.1",
     "commander": "^2.15.1",
+    "readline": "1.3.0",
     "require-all": "3.0.0",
     "shelljs": "^0.8.2",
     "upath": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "archiver": "3.1.1",
     "chalk": "^2.4.1",
     "commander": "^2.15.1",
-    "readline-sync": "1.4.10",
+    "readline-promise": "1.0.4",
     "require-all": "3.0.0",
     "shelljs": "^0.8.2",
     "upath": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "archiver": "3.1.1",
     "chalk": "^2.4.1",
     "commander": "^2.15.1",
-    "readline": "1.3.0",
+    "readline-sync": "1.4.10",
     "require-all": "3.0.0",
     "shelljs": "^0.8.2",
     "upath": "^1.1.2"


### PR DESCRIPTION
- Implements feature requested in PR #24 

- Added a `user-prompt` module to allow single access to a readline interface while running a command as well as support utility methods that can be used throughout the project.

- Updated Jest configration and added a test file for this new command. Not sure what else might be needed, or if we want to put the tests in their own directory, but I figured we needed to start somewhere.

Examples of the user-flow:

```
bscot@BSCOTT-PC /c/../Example/ -> and-cli-dev nuget -u
Please enter a package to upgade: AutoMapper
Please enter a version to upgrade 'AutoMapper' to: 7.0.0
[and-cli] Looking for csproj files under the current directory...
[and-cli] Looking for packages matching 'AutoMapper'...
[and-cli] 2 projects found with package 'AutoMapper'.
Continue? (y/n): y
[and-cli] Successfully updated 'AutoMapper' to version 7.0.0. Please check your git status before committing.
```

```
bscot@BSCOTT-PC /c/../Example/ -> and-cli-dev nuget -u
Please enter a package to upgade: DoesNotExist
Please enter a version to upgrade 'DoesNotExist' to: 1.0.0
[and-cli] Looking for csproj files under the current directory...
[and-cli] Looking for packages matching 'DoesNotExist'...
[and-cli] No projects found with package 'DoesNotExist'. Exiting.
```

```
bscot@BSCOTT-PC /c/../Example/ -> and-cli-dev nuget -u
Please enter a package to upgade: AutoMapper
Please enter a version to upgrade 'AutoMapper' to: 7.0.0
[and-cli] Looking for csproj files under the current directory...
[and-cli] Looking for packages matching 'AutoMapper'...
[and-cli] 2 projects found with package 'AutoMapper'.
Continue? (y/n): n
bscot@BSCOTT-PC /c/../Example/ -> 
```
