### PR TITLE
Fix dotnet-build module calling shell.exit on success

### DIFF
--- a/_modules/dotnet-build.js
+++ b/_modules/dotnet-build.js
@@ -48,7 +48,7 @@ const dotnetBuild = {
             shell.exit(buildResult.code);
         }
 
-        shell.exit(0);
+        return buildResult.code;
     },
 };
 


### PR DESCRIPTION
Updated `dotnet-build` module to pass build return status up to parent command instead of calling shell.exit