### PR TITLE
Support/fix failing tests

### DIFF
--- a/cli-dotnet-test.js
+++ b/cli-dotnet-test.js
@@ -206,10 +206,11 @@ program
 
 if (program.byProject === true) {
     dotnetTest.runSolutionByProject(program.skipClean);
-    return;
 }
 
-dotnetTest.runBySolution(program.skipClean);
+if (!program.byProject == null) {
+    dotnetTest.runBySolution(program.skipClean);
+}
 
 // #endregion Entrypoint / Command router
 

--- a/cli-dotnet-test.js
+++ b/cli-dotnet-test.js
@@ -208,7 +208,7 @@ if (program.byProject === true) {
     dotnetTest.runSolutionByProject(program.skipClean);
 }
 
-if (!program.byProject == null) {
+if (program.byProject == null || !program.byProject) {
     dotnetTest.runBySolution(program.skipClean);
 }
 


### PR DESCRIPTION
Update the short-circuiting in `cli-dotnet-test`'s entrypoint to be explicit `if` conditions for running by the entire solution or running the solution by each project, which was causing a in running the `cli-dotnet-test` test file due to a return outside of a function.

![image](https://user-images.githubusercontent.com/11774799/74850822-68b8b280-5308-11ea-880d-5a3be9d57430.png)
