### PR TITLE
Fixed reference error in dotnet command from sorting imports in dotnet-cli module

### DIFF
--- a/_modules/dotnet-cli.js
+++ b/_modules/dotnet-cli.js
@@ -2,7 +2,6 @@
 // #region Imports
 // -----------------------------------------------------------------------------------------
 
-const { red, tabbedNewLine } = formatters;
 const dir                    = require("./dir");
 const dotnetBuild            = require("./dotnet-build");
 const dotnetPath             = require("./dotnet-path");
@@ -12,6 +11,14 @@ const path                   = require("path");
 const shell                  = require("shelljs");
 
 // #endregion Imports
+
+// -----------------------------------------------------------------------------------------
+// #region Variables
+// -----------------------------------------------------------------------------------------
+
+const { red, tabbedNewLine } = formatters;
+
+// #endregion Variables
 
 // -----------------------------------------------------------------------------------------
 // #region Functions


### PR DESCRIPTION
When I was going back to refactor out all instances of the previous `/****..Region..*/` block, I must have sorted imports for the `dotnet-cli` module and not rerun the dotnet command. Due to the import destructuring of two functions in the `formatters` module coming before the `formatters` import itself, there was a reference error at runtime:

`
(node:44624) UnhandledPromiseRejectionWarning: ReferenceError: formatters is not defined
    at Object.<anonymous> (/Users/Brandon/AndcultureCode.Cli/_modules/dotnet-cli.js:5:32)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at require.run (/Users/Brandon/AndcultureCode.Cli/cli-dotnet.js:12:27)
    at Object.module.exports.run (/Users/Brandon/AndcultureCode.Cli/command-runner.js:10:11)
`

I separated them out so that it doesn't happen again.