### PR TITLE
Updating gitignore to NOT ignore  and instead ignore  prefixed direct…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 coverage
-cli-dotnet-*
+tmp-*

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -112,9 +112,10 @@ const testUtils = {
      *
      * @param {string} [prefix="tmp"] (Optional) Prefix for the directory name to be generated.
      */
-    createAndUseTmpDir(prefix = "tmp") {
+    createAndUseTmpDir(prefix = "") {
+        const defaultPrefix = "tmp";
         const oldPwd = shell.pwd().toString();
-        const tmpDir = upath.toUnix(path.join(oldPwd, `${prefix}-${faker.random.uuid()}`));
+        const tmpDir = upath.toUnix(path.join(oldPwd, `${defaultPrefix}-${prefix}-${faker.random.uuid()}`));
 
         shell.mkdir("-p", tmpDir);
         shell.cd(tmpDir);


### PR DESCRIPTION
gitignore was not allowing `dotnet-test` module to be published with npm. That's hazardous...
Updated gitignore, and added a `tmp` prefix to the temp directory in `testUtils`. Additional param can still be passed the same way. 