### PR TITLE
Issue #56 Allow for user-defined aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,125 @@ For more examples, or to see what the full project structure might look like, se
 
 [`AndcultureCode.Cli.PluginExample`](https://github.com/AndcultureCode/AndcultureCode.Cli.PluginExample)
 
+## Aliasing commands
+
+Existing commands & options can be aliased so they are easier to type or remember. Aliases can be registered in your `package.json` file, or registered in your extended CLI through the `command-registry` module.
+
+### Registering aliases in your package.json file
+
+To add aliases without any additional code, add an `and-cli` section with an `aliases` object underneath. Each key of the `aliases` section will be the alias you want to use (which cannot contain spaces), and the value will be the command and any options that should be run in place of it.
+
+_Note: when defining aliases, the command/option string to be mapped should not contain the CLI name itself. See example below._
+
+```JSON
+{
+    "and-cli": {
+        "aliases": {
+            "d": "dotnet",
+            "dcRb": "dotnet -cRb",
+        }
+    }
+}
+```
+
+If you are extending the `and-cli` with your own commands, you will also need to call `commandRegistry.registerAliasesFromConfig()` to read the aliases from `package.json`.
+
+_Note: Ensure you are calling `commandRegistry.parseWithAliases()`, or the preprocessing to handle the aliases will not run._
+
+```JS
+#!/usr/bin/env node
+
+// -----------------------------------------------------------------------------------------
+// #region Imports
+// -----------------------------------------------------------------------------------------
+
+const commandRegistry = require("and-cli/modules/command-registry");
+const program = require("and-cli");
+
+// #endregion Imports
+
+// -----------------------------------------------------------------------------------------
+// #region Entrypoint
+// -----------------------------------------------------------------------------------------
+
+// Register the base 'dotnet' command and register aliases from the package.json file
+commandRegistry
+    .registerBaseCommand("dotnet")
+    .registerAliasesFromConfig();
+
+// Ensure you call parseWithAliases() in place of program.parse() to preprocess the arguments.
+commandRegistry.parseWithAliases();
+
+// #endregion Entrypoint
+```
+
+### Registering aliases through the command registry
+
+Aliases can be registered just like commands would be with the `commandRegistry.registerAlias()` function.
+
+_Note: Ensure you are calling `commandRegistry.parseWithAliases()`, or the preprocessing to handle the aliases will not run._
+
+```JS
+#!/usr/bin/env node
+
+// -----------------------------------------------------------------------------------------
+// #region Imports
+// -----------------------------------------------------------------------------------------
+
+const commandRegistry = require("and-cli/modules/command-registry");
+const program = require("and-cli");
+
+// #endregion Imports
+
+// -----------------------------------------------------------------------------------------
+// #region Entrypoint
+// -----------------------------------------------------------------------------------------
+
+// Register the base 'dotnet' command and alias some of its options
+commandRegistry
+    .registerBaseCommand("dotnet")
+    .registerAlias({
+        command: "d",
+        description: "dotnet",
+    })
+    .registerAlias({
+        command: "dcRb",
+        description: "dotnet -cRb",
+    });
+
+// Ensure you call parseWithAliases() in place of program.parse() to preprocess the arguments.
+commandRegistry.parseWithAliases();
+
+// #endregion Entrypoint
+```
+
+Regardless of how they are registered, aliases will be specially noted in the help menu of the CLI.
+
+```SH
+Usage: and-cli [options] [command]
+
+andculture cli
+
+Options:
+  -V, --version   output the version number
+  -h, --help      display help for command
+
+Commands:
+  copy            Copy files and/or directories
+  d               (alias) dotnet
+  dcRb            (alias) dotnet -cRb
+  deploy          Deploy various application types
+  dotnet          Run various dotnet commands for the project
+  dotnet-test     Run various dotnet test runner commands for the project
+  github          Commands for interacting with AndcultureCode github resources
+  install         Collection of commands related to installation and configuration of the and-cli
+  migration       Run commands to manage Entity Framework migrations
+  nuget           Manages publishing of nuget dotnet core projects
+  webpack         Run various webpack commands for the project
+  webpack-test    Run various webpack test commands for the project
+  help [command]  display help for command
+```
+
 ## Troubleshooting
 
 ### Leading slash auto-converted to absolute path

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,6 @@ module.exports = {
     coverageDirectory: "coverage",
     restoreMocks: true,
     setupFiles: ["./tests/setup.js"],
-    setupFilesAfterEnv: ["./tests/setup-after-env.js"],
+    setupFilesAfterEnv: ["./tests/setup-after-env.js", "jest-extended"],
     testEnvironment: "node",
 };

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -28,6 +28,9 @@ module.exports.HELP_OPTIONS = ["-h", "--help"];
 /** Constant to hold the 'node_modules' directory string */
 module.exports.NODE_MODULES = "node_modules";
 
+/** Constant to hold the 'package.json' file string */
+module.exports.PACKAGE_JSON = "package.json";
+
 /** Constant to hold the standard 'unknown command' output from Commander when parsing arguments */
 module.exports.UNKNOWN_COMMAND = "unknown command";
 

--- a/modules/package-config.js
+++ b/modules/package-config.js
@@ -1,0 +1,97 @@
+// -----------------------------------------------------------------------------------------
+// #region Imports
+// -----------------------------------------------------------------------------------------
+
+const { CoreUtils } = require("andculturecode-javascript-core");
+const { CLI_NAME, PACKAGE_JSON } = require("./constants");
+const finder = require("find-package-json");
+const upath = require("upath");
+
+// #endregion Imports
+
+// -----------------------------------------------------------------------------------------
+// #region Constants
+// -----------------------------------------------------------------------------------------
+
+/**
+ * Default object to be returned if the 'and-cli' section of the package.json is missing
+ */
+const _defaultConfig = {
+    aliases: {},
+};
+
+// #endregion Constants
+
+// -----------------------------------------------------------------------------------------
+// #region Functions
+// -----------------------------------------------------------------------------------------
+
+/**
+ * Module to wrap access to the package.json file. Any reading/transforming of data from that file
+ * should live here.
+ */
+const packageConfig = {
+    DEFAULT_CONFIG: _defaultConfig,
+
+    /**
+     * Returns the package.json file for the base `and-cli` package.
+     */
+    getBase() {
+        return require(upath.join("..", PACKAGE_JSON));
+    },
+
+    /**
+     * Returns the 'description' field from the package.json file of the base `and-cli` package.
+     */
+    getBaseDescription() {
+        const { description } = this.getBase();
+        return description;
+    },
+
+    /**
+     * Returns the 'version' field from the package.json file of the base `and-cli` package.
+     */
+    getBaseVersion() {
+        const { version } = this.getBase();
+        return version;
+    },
+
+    /**
+     * Returns the package.json file nearest to the current directory. Use this if you need to
+     * retrieve the package.json file for your local project and not the base package.json.
+     *
+     * Note that this will traverse upwards from the current directory to look for a package.json,
+     * and return the first match. If no package.json is found, it will return the base package.json
+     */
+    getLocal() {
+        const { value: localPackageJson } = finder().next();
+        if (localPackageJson == null) {
+            return this.getBase();
+        }
+
+        return localPackageJson;
+    },
+
+    /**
+     * Returns the 'and-cli' config section for the currently executing package, or a default object.
+     */
+    getLocalConfigOrDefault() {
+        let packageJson = this.getLocal();
+        if (packageJson[CLI_NAME] == null) {
+            return _defaultConfig;
+        }
+
+        // Return the 'and-cli' section merged with the default config structure if certain properties are not set
+        return CoreUtils.merge(packageJson[CLI_NAME], _defaultConfig);
+    },
+};
+
+// #endregion Functions
+
+// -----------------------------------------------------------------------------------------
+// #region Exports
+// -----------------------------------------------------------------------------------------
+
+module.exports = packageConfig;
+
+// #endregion Exports

--- a/modules/package-config.test.js
+++ b/modules/package-config.test.js
@@ -1,0 +1,177 @@
+// -----------------------------------------------------------------------------------------
+// #region Mocks
+// -----------------------------------------------------------------------------------------
+
+jest.mock("find-package-json");
+
+// #endregion Mocks
+
+// -----------------------------------------------------------------------------------------
+// #region Imports
+// -----------------------------------------------------------------------------------------
+
+const { CLI_NAME } = require("./constants");
+const packageConfig = require("./package-config");
+const packageJson = require("../package.json");
+const faker = require("faker");
+const finder = require("find-package-json");
+const testUtils = require("../tests/test-utils");
+
+// #endregion Imports
+
+// -----------------------------------------------------------------------------------------
+// #region Tests
+// -----------------------------------------------------------------------------------------
+
+describe("packageConfig", () => {
+    // -----------------------------------------------------------------------------------------
+    // #region getBase
+    // -----------------------------------------------------------------------------------------
+
+    describe("getBase", () => {
+        test("it returns the package.json as an object", () => {
+            // Arrange & Act
+            const result = packageConfig.getBase();
+
+            // Assert
+            expect(result).toStrictEqual(packageJson);
+        });
+    });
+
+    // #endregion getBase
+
+    // -----------------------------------------------------------------------------------------
+    // #region getBaseDescription
+    // -----------------------------------------------------------------------------------------
+
+    describe("getBaseDescription", () => {
+        test("it returns the 'description' property", () => {
+            // Arrange & Act
+            const result = packageConfig.getBaseDescription();
+
+            // Assert
+            expect(result).toBe(packageJson.description);
+        });
+    });
+
+    // #endregion getBaseDescription
+
+    // -----------------------------------------------------------------------------------------
+    // #region getBaseVersion
+    // -----------------------------------------------------------------------------------------
+
+    describe("getBaseVersion", () => {
+        test("it returns the 'version' property", () => {
+            // Arrange & Act
+            const result = packageConfig.getBaseVersion();
+
+            // Assert
+            expect(result).toBe(packageJson.version);
+        });
+    });
+
+    // #endregion getBaseVersion
+
+    // -----------------------------------------------------------------------------------------
+    // #region getLocal
+    // -----------------------------------------------------------------------------------------
+
+    describe("getLocal", () => {
+        test("given package.json cannot be found, it returns the base package.json", () => {
+            // Arrange
+            finder.mockImplementation(() => {
+                return {
+                    next() {
+                        return { value: undefined };
+                    },
+                };
+            });
+            const getBaseSpy = jest.spyOn(packageConfig, "getBase");
+
+            // Act
+            const result = packageConfig.getLocal();
+
+            // Assert
+            expect(result).toStrictEqual(packageJson);
+            expect(getBaseSpy).toHaveBeenCalled();
+        });
+
+        test("given package.json can be found, it returns the object", () => {
+            // Arrange
+            const mockPackageJson = {};
+            const keyCount = testUtils.randomNumber(1, 10);
+            // Note: I think we're doing this somewhere else (generating a random object), might be
+            // time to bust out a test utility function.
+            for (let i = 0; i < keyCount; i++) {
+                const key = faker.random.uuid();
+                if (mockPackageJson[key] != null) {
+                    return;
+                }
+                mockPackageJson[key] = testUtils.randomNumber();
+            }
+
+            finder.mockImplementation(() => {
+                return {
+                    next() {
+                        return { value: mockPackageJson };
+                    },
+                };
+            });
+
+            const result = packageConfig.getLocal();
+
+            // Assert
+            expect(result).toStrictEqual(mockPackageJson);
+        });
+    });
+
+    // #endregion getLocal
+
+    // -----------------------------------------------------------------------------------------
+    // #region getLocalConfigOrDefault
+    // -----------------------------------------------------------------------------------------
+
+    describe("getLocalConfigOrDefault", () => {
+        test("given no 'and-cli' section exists, it returns the default config", () => {
+            // Arrange
+            const getLocalSpy = jest
+                .spyOn(packageConfig, "getLocal")
+                .mockImplementation(() => {
+                    return {};
+                });
+
+            // Act
+            const result = packageConfig.getLocalConfigOrDefault();
+
+            // Assert
+            expect(getLocalSpy).toHaveBeenCalled();
+            expect(result).toStrictEqual(packageConfig.DEFAULT_CONFIG);
+        });
+
+        describe("given 'and-cli' section exists", () => {
+            test("given no 'aliases' section exists, it returns a default value for the 'aliases' section", () => {
+                // Arrange
+                const getLocalSpy = jest
+                    .spyOn(packageConfig, "getLocal")
+                    .mockImplementation(() => {
+                        return {
+                            [CLI_NAME]: {},
+                        };
+                    });
+
+                // Act
+                const result = packageConfig.getLocalConfigOrDefault();
+
+                // Assert
+                expect(getLocalSpy).toHaveBeenCalled();
+                expect(result.aliases).toStrictEqual(
+                    packageConfig.DEFAULT_CONFIG.aliases
+                );
+            });
+        });
+    });
+
+    // #endregion getLocalConfigOrDefault
+});
+
+// #endregion Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,9 +920,9 @@
             }
         },
         "andculturecode-javascript-core": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/andculturecode-javascript-core/-/andculturecode-javascript-core-0.1.6.tgz",
-            "integrity": "sha512-gA1SeyBxo4o95+YEtXFgQMsDRuFncm0ZORs8sLVjNJrv9CHrvvPTZ/hvGkPaS65CUa5C7IXlwHhMP+DinDc1fw==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/andculturecode-javascript-core/-/andculturecode-javascript-core-0.2.0.tgz",
+            "integrity": "sha512-TmbOIyu2+3LnLM20duxaptyGJCokItBTBF//374yU/ejUC8D1C5ekz8pAtd2CIZUgsocxpAOTeIxSt8hU1k5iw==",
             "requires": {
                 "axios": "0.19.2",
                 "humanize-plus": "1.8.2",
@@ -2152,6 +2152,11 @@
                 "to-regex-range": "^5.0.1"
             }
         },
+        "find-package-json": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+            "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw=="
+        },
         "find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2951,6 +2956,360 @@
                 "jest-mock": "^25.3.0",
                 "jest-util": "^25.3.0",
                 "semver": "^6.3.0"
+            }
+        },
+        "jest-extended": {
+            "version": "0.11.5",
+            "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-0.11.5.tgz",
+            "integrity": "sha512-3RsdFpLWKScpsLD6hJuyr/tV5iFOrw7v6YjA3tPdda9sJwoHwcMROws5gwiIZfcwhHlJRwFJB2OUvGmF3evV/Q==",
+            "dev": true,
+            "requires": {
+                "expect": "^24.1.0",
+                "jest-get-type": "^22.4.3",
+                "jest-matcher-utils": "^22.0.0"
+            },
+            "dependencies": {
+                "@jest/console": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+                    "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/source-map": "^24.9.0",
+                        "chalk": "^2.0.1",
+                        "slash": "^2.0.0"
+                    }
+                },
+                "@jest/source-map": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+                    "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+                    "dev": true,
+                    "requires": {
+                        "callsites": "^3.0.0",
+                        "graceful-fs": "^4.1.15",
+                        "source-map": "^0.6.0"
+                    }
+                },
+                "@jest/test-result": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+                    "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/console": "^24.9.0",
+                        "@jest/types": "^24.9.0",
+                        "@types/istanbul-lib-coverage": "^2.0.0"
+                    }
+                },
+                "@jest/types": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+                    "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^13.0.0"
+                    }
+                },
+                "@types/yargs": {
+                    "version": "13.0.10",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.10.tgz",
+                    "integrity": "sha512-MU10TSgzNABgdzKvQVW1nuuT+sgBMWeXNc3XOs5YXV5SDAK+PPja2eUuBNB9iqElu03xyEDqlnGw0jgl4nbqGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yargs-parser": "*"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+                    "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+                    "dev": true
+                },
+                "expect": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+                    "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^24.9.0",
+                        "ansi-styles": "^3.2.0",
+                        "jest-get-type": "^24.9.0",
+                        "jest-matcher-utils": "^24.9.0",
+                        "jest-message-util": "^24.9.0",
+                        "jest-regex-util": "^24.9.0"
+                    },
+                    "dependencies": {
+                        "jest-get-type": {
+                            "version": "24.9.0",
+                            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+                            "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+                            "dev": true
+                        },
+                        "jest-matcher-utils": {
+                            "version": "24.9.0",
+                            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+                            "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+                            "dev": true,
+                            "requires": {
+                                "chalk": "^2.0.1",
+                                "jest-diff": "^24.9.0",
+                                "jest-get-type": "^24.9.0",
+                                "pretty-format": "^24.9.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "jest-diff": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+                    "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1",
+                        "diff-sequences": "^24.9.0",
+                        "jest-get-type": "^24.9.0",
+                        "pretty-format": "^24.9.0"
+                    },
+                    "dependencies": {
+                        "jest-get-type": {
+                            "version": "24.9.0",
+                            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+                            "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+                            "dev": true
+                        }
+                    }
+                },
+                "jest-get-type": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+                    "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+                    "dev": true
+                },
+                "jest-matcher-utils": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+                    "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1",
+                        "jest-get-type": "^22.4.3",
+                        "pretty-format": "^22.4.3"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                            "dev": true
+                        },
+                        "pretty-format": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+                            "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0",
+                                "ansi-styles": "^3.2.0"
+                            }
+                        }
+                    }
+                },
+                "jest-message-util": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+                    "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@jest/test-result": "^24.9.0",
+                        "@jest/types": "^24.9.0",
+                        "@types/stack-utils": "^1.0.1",
+                        "chalk": "^2.0.1",
+                        "micromatch": "^3.1.10",
+                        "slash": "^2.0.0",
+                        "stack-utils": "^1.0.1"
+                    }
+                },
+                "jest-regex-util": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+                    "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "pretty-format": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+                    "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^24.9.0",
+                        "ansi-regex": "^4.0.0",
+                        "ansi-styles": "^3.2.0",
+                        "react-is": "^16.8.4"
+                    }
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                }
             }
         },
         "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
         "cli"
     ],
     "scripts": {
-        "configure:git": "echo Ensuring git hooksPath is set to .githooks directory; git config core.hooksPath .githooks; chmod +x .githooks/*",
+        "configure:git": "echo Ensuring git hooksPath is set to .githooks directory && git config core.hooksPath .githooks && chmod +x .githooks/*",
         "postpublish": "cross-env-shell \"git add -A && git commit -m \"$npm_package_version\" && git push origin master\"",
-        "preinstall": "npm run configure:git",
         "test": "jest",
-        "test:unit": "jest --coverage \"^((?!and-cli).)*$\"",
+        "test:unit": "jest \"^((?!and-cli).)*$\"",
         "test:integration": "jest --runInBand \"(and-cli)(.)*(.test.js)\"",
         "watch:test": "jest --watch"
     },
@@ -30,9 +29,10 @@
     "homepage": "https://github.com/AndcultureCode/AndcultureCode.Cli#readme",
     "dependencies": {
         "@octokit/rest": "18.0.0",
-        "andculturecode-javascript-core": "0.1.6",
+        "andculturecode-javascript-core": "0.2.0",
         "archiver": "3.1.1",
         "commander": "5.1.0",
+        "find-package-json": "1.2.0",
         "fkill": "6.2.0",
         "ps-list": "6.2.0",
         "readline-promise": "1.0.4",
@@ -46,6 +46,7 @@
         "cross-env": "6.0.3",
         "faker": "4.1.0",
         "jest": "25.3.0",
+        "jest-extended": "0.11.5",
         "nock": "12.0.3",
         "prettier": "1.19.1",
         "pryjs": "1.0.3"


### PR DESCRIPTION
Fixes #56 Allow for user-defined aliases

Adds the ability to register aliases for commands/options through the package.json, or through code. Updated the readme to have examples for both. I plan to update the plugin example readme along with this, too. The idea is that you can add aliases to the package.json without having to extend the `and-cli` for additional commands, or, if you are extending the `and-cli`, you can also add them programmatically with an API similar to the `registerCommand` function.


-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
