### PR TITLE
Issue #110 Parsing short-circuits prematurely when command without flags given but no matching alias is found

### DIFF
--- a/modules/command-registry.js
+++ b/modules/command-registry.js
@@ -132,7 +132,8 @@ const _preprocessArgsForAliases = () => {
         return undefined;
     }
 
-    const lastArg = process.argv.pop();
+    // Cloning with spread operator to avoid mutating original process.argv reference
+    const lastArg = [...process.argv].pop();
 
     // Return the alias command that matches the given input, or undefined
     return aliases.find((alias) => alias.command === lastArg);

--- a/modules/command-registry.test.js
+++ b/modules/command-registry.test.js
@@ -213,11 +213,20 @@ describe("commandRegistry", () => {
 
         describe("given no aliases are registered", () => {
             test("it calls program.parse with process.argv", () => {
-                // Arrange & Act
+                // Arrange
+                const expectedArgv = [
+                    testUtils.randomWord(),
+                    testUtils.randomWord(),
+                    testUtils.randomWord(),
+                ];
+                // Cloning to ensure we have a separate reference to work with
+                process.argv = [...expectedArgv];
+
+                // Act
                 commandRegistry.parseWithAliases();
 
                 // Assert
-                expect(programParseSpy).toHaveBeenCalledWith(process.argv);
+                expect(programParseSpy).toHaveBeenCalledWith(expectedArgv); // The test should fail if something modifies process.argv in-place
             });
         });
 
@@ -226,36 +235,44 @@ describe("commandRegistry", () => {
                 // Arrange
                 const commandDefinition = seedRandomCommand();
                 commandRegistry.registerAlias(commandDefinition);
-                process.argv = [];
+                const expectedArgv = [];
+
                 // This is the important setup
                 const argvCount = testUtils.randomNumber(0, 2);
                 for (let i = 0; i < argvCount; i++) {
-                    process.argv.push(testUtils.randomWord());
+                    expectedArgv.push(testUtils.randomWord());
                 }
+
+                // Cloning to ensure we have a separate reference to work with
+                process.argv = [...expectedArgv];
 
                 // Act
                 commandRegistry.parseWithAliases();
 
                 // Assert
-                expect(programParseSpy).toHaveBeenCalledWith(process.argv);
+                expect(programParseSpy).toHaveBeenCalledWith(expectedArgv); // The test should fail if something modifies process.argv in-place
             });
 
             test("when > 3 args are provided, it calls program.parse with process.argv", () => {
                 // Arrange
                 const commandDefinition = seedRandomCommand();
                 commandRegistry.registerAlias(commandDefinition);
-                process.argv = [];
+                const expectedArgv = [];
+
                 // This is the important setup
                 const argvCount = testUtils.randomNumber(4, 100);
                 for (let i = 0; i < argvCount; i++) {
-                    process.argv.push(testUtils.randomWord());
+                    expectedArgv.push(testUtils.randomWord());
                 }
+
+                // Cloning to ensure we have a separate reference to work with
+                process.argv = [...expectedArgv];
 
                 // Act
                 commandRegistry.parseWithAliases();
 
                 // Assert
-                expect(programParseSpy).toHaveBeenCalledWith(process.argv);
+                expect(programParseSpy).toHaveBeenCalledWith(expectedArgv); // The test should fail if something modifies process.argv in-place
             });
 
             test("when 3rd arg matching an alias provided, it calls program.parse with transformed args", () => {
@@ -288,17 +305,19 @@ describe("commandRegistry", () => {
                 const commandDefinition = seedRandomCommand();
                 commandRegistry.registerAlias(commandDefinition);
                 // First two args don't really matter
-                process.argv = [
+                const expectedArgv = [
                     testUtils.randomWord(),
                     testUtils.randomWord(),
                     `${commandDefinition.command}${testUtils.randomWord()}`, // This is the important setup
                 ];
+                // Cloning to ensure we have a separate reference to work with
+                process.argv = [...expectedArgv];
 
                 // Act
                 commandRegistry.parseWithAliases();
 
                 // Assert
-                expect(programParseSpy).toHaveBeenCalledWith(process.argv);
+                expect(programParseSpy).toHaveBeenCalledWith(expectedArgv); // The test should fail if something modifies process.argv in-place
             });
         });
     });


### PR DESCRIPTION
Fixes #110 

Fix mutated process.argv reference which was popping the last argument off the array when preprocessing for aliases, which would cause the help menu to be displayed when a single command was specified but matched no defined aliases

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
