### PR TITLE
Opt-in automatic forking for AndcultureCode repos

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -250,4 +250,6 @@ Starts webpack built projects located in our team's conventional 'frontend' fold
 Series of commands to synchronize a development workspace for easy contributions for AndcultureCode repositories.
 
 -   `and-cli workspace` - Clones all public AndcultureCode organization repositories into current folder
--   `and-cli workspace --u|usernames <username1,username2,...>` - Additionally clones forks of the AndcultureCode repositories for the supplied user(s)
+-   `and-cli workspace -u|--usernames <username1,username2,...>` - Additionally clones forks of the AndcultureCode repositories for the supplied user(s)
+-   `and-cli workspace -f|--fork` - Will create forks of AndcultureCode repos for currently authenticated github user
+-   `and-cli workspace --fork --usernames yourusername` - Combining `usernames` and `fork` flag, you can have your full workspace forked and those forks automatically cloned all in one pass.

--- a/and-cli-workspace.js
+++ b/and-cli-workspace.js
@@ -36,8 +36,6 @@ require("./command-runner").run(async () => {
         const userRepos = await github.repositoriesByAndculture(username);
         const cloneUserResults = cloneRepositories(userRepos, username);
 
-        echo.newLine();
-        echo.message("Results");
         echoCloneResults(cloneUserResults);
     };
 
@@ -109,6 +107,8 @@ require("./command-runner").run(async () => {
     };
 
     const echoCloneResults = (cloneResults) => {
+        echo.newLine();
+        echo.message("Results");
         echo.success(` - Successful: ${cloneResults.successCount}`);
         echo.message(yellow(` - Unmodified: ${cloneResults.unmodifiedCount}`));
         echo.message(red(` - Errored: ${cloneResults.errorCount}`));

--- a/and-cli-workspace.js
+++ b/and-cli-workspace.js
@@ -35,6 +35,9 @@ require("./command-runner").run(async () => {
         );
         const userRepos = await github.repositoriesByAndculture(username);
         const cloneUserResults = cloneRepositories(userRepos, username);
+
+        echo.newLine();
+        echo.message("Results");
         echoCloneResults(cloneUserResults);
     };
 
@@ -73,10 +76,36 @@ require("./command-runner").run(async () => {
             }
 
             echo.success(`Cloned '${repo.full_name}'`);
+
+            configureNewClone(repo, prefix);
+
             results.successCount++;
         });
 
         return results;
+    };
+
+    const configureNewClone = (repo, prefix) => {
+        echo.message(` - Configuring ${repo.full_name}...`);
+
+        // Additional configuration if its a clone of a fork
+        if (!repo.fork) {
+            return;
+        }
+
+        const folder = git.getCloneDirectoryName(repo.name, prefix);
+        shell.cd(folder);
+
+        const addUpgradeResult = git.addRemote(
+            "upstream",
+            `git://github.com/AndcultureCode/${repo.name}.git`
+        );
+
+        if (addUpgradeResult) {
+            echo.message(` - Configured upstream for '${repo.full_name}'`);
+        }
+
+        shell.cd("..");
     };
 
     const echoCloneResults = (cloneResults) => {

--- a/and-cli-workspace.js
+++ b/and-cli-workspace.js
@@ -98,6 +98,11 @@ require("./command-runner").run(async () => {
             userForks.every((userFork) => !userFork.name.startsWith(repo.name))
         );
 
+        if (reposToFork.length === 0) {
+            echo.message(" - No new repositories to fork.");
+            return;
+        }
+
         await js.asyncForEach(reposToFork, async (repoToFork) => {
             await github.fork(repoToFork.owner.login, repoToFork.name);
         });
@@ -127,25 +132,27 @@ require("./command-runner").run(async () => {
 
     echo.header("Configuring workspace");
 
+    // Initiate forks for authenticated user
+    // -------------------------------------
+    if (program.fork != null) {
+        echo.message("Forking any outstanding AndcultureCode repositories...");
+        await forkRepositories();
+        echo.newLine();
+    }
+
     // Clone top-level AndcultureCode repositories
     // -------------------------------------------
     echo.message("Synchronizing AndcultureCode repositories...");
     const repos = await github.repositoriesByAndculture();
     const cloneResults = cloneRepositories(repos);
     echoCloneResults(cloneResults);
-
     echo.newLine();
 
     // Clone user forks of AndcultureCode repositories
     // -----------------------------------------------
     if (StringUtils.hasValue(program.usernames)) {
         await cloneForUsers(program.usernames);
-    }
-
-    // Initiate forks for authenticated user
-    // -------------------------------------
-    if (program.fork != null) {
-        await forkRepositories();
+        echo.newLine();
     }
 
     // #endregion Entrypoint

--- a/and-cli-workspace.js
+++ b/and-cli-workspace.js
@@ -94,12 +94,12 @@ require("./command-runner").run(async () => {
         const folder = git.getCloneDirectoryName(repo.name, prefix);
         shell.cd(folder);
 
-        const addUpgradeResult = git.addRemote(
+        const addUpstreamResult = git.addRemote(
             "upstream",
             `git://github.com/AndcultureCode/${repo.name}.git`
         );
 
-        if (addUpgradeResult) {
+        if (addUpstreamResult) {
             echo.message(` - Configured upstream for '${repo.full_name}'`);
         }
 

--- a/and-cli-workspace.js
+++ b/and-cli-workspace.js
@@ -98,9 +98,12 @@ require("./command-runner").run(async () => {
             userForks.every((userFork) => !userFork.name.startsWith(repo.name))
         );
 
-        reposToFork.forEach((repoToFork) => {
-            echo.success(`Initiating fork of '${repoToFork.full_name}'...`);
+        await js.asyncForEach(reposToFork, async (repoToFork) => {
+            await github.fork(repoToFork.owner.login, repoToFork.name);
         });
+
+        echo.newLine();
+        echo.success("Successfully created all outstanding forks");
     };
 
     // #endregion Functions

--- a/modules/git.js
+++ b/modules/git.js
@@ -14,6 +14,23 @@ const shell = require("shelljs");
 
 const git = {
     /**
+     * Configures a new remote when run in root of git repository
+     * @param {string} name local identifier for a new remote
+     * @param {string} url absolute url corresponding to remote destination
+     */
+    addRemote(name, url) {
+        if (!this.isRepositoryRoot()) {
+            echo.error(
+                `Cannot add remote '${name}'. Current directory '${shell.pwd()} is not the root of a git repository.`
+            );
+            return false;
+        }
+
+        const command = `git remote add ${name} ${url}`;
+        return shell.exec(command).code === 0;
+    },
+
+    /**
      * Clone a git repository
      * @param {string} name Name of repository being cloned
      * @param {string} url Absolute HTTPS or SSH repository URL
@@ -61,6 +78,15 @@ const git = {
     isCloned(repoName, prefix) {
         const folder = git.getCloneDirectoryName(repoName, prefix);
         return fs.existsSync(folder);
+    },
+
+    /**
+     * Verifies if we are in a git repo
+     */
+    isRepositoryRoot() {
+        // not verifying integrity at this time
+        // consider `git rev-parse --is-inside-work-tree at a future time
+        return fs.existsSync(".git");
     },
 
     /**

--- a/modules/github.js
+++ b/modules/github.js
@@ -94,6 +94,9 @@ const github = {
 
             return response.data;
         } catch (e) {
+            echo.error(
+                `Error retrieving repository for ${owner}/${repoName} - ${e}`
+            );
             return null;
         }
     },

--- a/modules/github.js
+++ b/modules/github.js
@@ -3,17 +3,15 @@
 // -----------------------------------------------------------------------------------------
 
 const { createNetrcAuth } = require("octokit-auth-netrc");
+const { Octokit } = require("@octokit/rest");
+const { StringUtils } = require("andculturecode-javascript-core");
 const echo = require("./echo");
 const fs = require("fs");
 const git = require("./git");
 const js = require("./js");
-const { Octokit } = require("@octokit/rest");
 const os = require("os");
 const upath = require("upath");
 const userPrompt = require("./user-prompt");
-const { StringUtils } = require("andculturecode-javascript-core");
-const { fork } = require("child_process");
-const { sleep } = require("./js");
 
 // #endregion Imports
 

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -95,6 +95,48 @@ describe("github", () => {
     //#endregion description
 
     // -----------------------------------------------------------------------------------------
+    // #region getRepo
+    // -----------------------------------------------------------------------------------------
+
+    describe("getRepo", () => {
+        test("given username does not exist, returns null", async () => {
+            // Arrange
+            const invalidUser = `AndcultureCode${faker.random.uuid()}`;
+
+            // Act & Assert
+            expect(
+                await github.getRepo(invalidUser, "AndcultureCode.Cli")
+            ).toBeNull();
+        });
+
+        test("given repo does not exist, returns null", async () => {
+            // Arrange
+            const invalidRepo = `AndcultureCode.Cli${faker.random.uuid()}`;
+
+            // Act & Assert
+            expect(
+                await github.getRepo("AndcultureCode", invalidRepo)
+            ).toBeNull();
+        });
+
+        test("given username and repo exists, returns repo", async () => {
+            // Arrange
+            const expectedUsername = "AndcultureCode";
+            const expectedRepo = "AndcultureCode.Cli";
+
+            // Act
+            const result = await github.getRepo(expectedUsername, expectedRepo);
+
+            // Assert
+            expect(result).not.toBeNull();
+            expect(result.name).toBe(expectedRepo);
+            expect(result.owner.login).toBe(expectedUsername);
+        });
+    });
+
+    // #endregion getRepo
+
+    // -----------------------------------------------------------------------------------------
     // #region repositories
     // -----------------------------------------------------------------------------------------
 

--- a/modules/js.js
+++ b/modules/js.js
@@ -25,11 +25,16 @@ const js = {
 
     /**
      * Blocks for a given duration
-     * @param {number} ms number of milli-seconds to wait
+     * @param {number} milliseconds number of milli-seconds to wait
      */
-    sleep(ms) {
+    sleep(milliseconds) {
         return new Promise((resolve) => {
-            setTimeout(resolve, ms);
+            if (milliseconds <= 0) {
+                resolve();
+                return;
+            }
+
+            setTimeout(resolve, milliseconds);
         });
     },
 

--- a/modules/js.js
+++ b/modules/js.js
@@ -2,6 +2,7 @@
 // #region Imports
 // -----------------------------------------------------------------------------------------
 
+const { CoreUtils } = require("andculturecode-javascript-core");
 const echo = require("./echo");
 const fs = require("fs");
 
@@ -21,21 +22,6 @@ const js = {
         for (let index = 0; index < array.length; index++) {
             await callback(array[index], index, array);
         }
-    },
-
-    /**
-     * Blocks for a given duration
-     * @param {number} milliseconds number of milli-seconds to wait
-     */
-    sleep(milliseconds) {
-        return new Promise((resolve) => {
-            if (milliseconds <= 0) {
-                resolve();
-                return;
-            }
-
-            setTimeout(resolve, milliseconds);
-        });
     },
 
     /**
@@ -70,7 +56,7 @@ const js = {
                 return;
             }
 
-            await this.sleep(interval);
+            await CoreUtils.sleep(interval);
 
             elapsedTime = new Date() - startTime;
             if (elapsedTime < duration) {

--- a/modules/js.test.js
+++ b/modules/js.test.js
@@ -1,0 +1,183 @@
+// -----------------------------------------------------------------------------------------
+// #region Imports
+// -----------------------------------------------------------------------------------------
+
+const faker = require("faker");
+const js = require("./js");
+const nock = require("nock");
+const shell = require("shelljs");
+const testUtils = require("../tests/test-utils");
+
+// #endregion Imports
+
+// -----------------------------------------------------------------------------------------
+// #region Tests
+// -----------------------------------------------------------------------------------------
+
+describe("js", () => {
+    // -----------------------------------------------------------------------------------------
+    // #region sleep
+    // -----------------------------------------------------------------------------------------
+
+    describe("sleep", () => {
+        test("when milliseconds less than or equal to 0, resolves immediately", async () => {
+            // Arrange
+            const startTime = new Date();
+
+            // Act
+            await js.sleep(faker.random.number({ min: -500, max: 0 }));
+
+            // Assert
+            const elapsed = new Date() - startTime;
+            expect(elapsed).toBeLessThanOrEqual(10); // pad timing a tad so avoid failures for generally slower execution
+        });
+
+        test("execution is paused for milliseconds provided", async () => {
+            // Arrange
+            const expectedDuration = faker.random.number({ min: 1, max: 500 });
+            const startTime = new Date();
+
+            // Act
+            await js.sleep(expectedDuration);
+
+            // Assert
+            const elapsed = new Date() - startTime;
+            expect(elapsed).toBeGreaterThanOrEqual(expectedDuration);
+        });
+    });
+
+    // #endregion sleep
+
+    // -----------------------------------------------------------------------------------------
+    // #region waitFor
+    // -----------------------------------------------------------------------------------------
+
+    describe("waitFor", () => {
+        test.each`
+            invalidValue
+            ${null}
+            ${undefined}
+        `(
+            "when callbackAsync $invalidValue, throws error",
+            async ({ invalidValue }) => {
+                // Arrange
+                let hasError = false;
+                const interval = faker.random.number({ max: 5 });
+                const duration = faker.random.number({ max: 5 });
+
+                // Act
+                try {
+                    await js.waitFor(invalidValue, interval, duration);
+                } catch (e) {
+                    hasError = true;
+                }
+
+                // Assert
+                expect(hasError).toBeTrue();
+            }
+        );
+
+        test.each`
+            invalidValue
+            ${0}
+            ${-1}
+            ${-100}
+        `(
+            "when interval $invalidValue, throws error",
+            async ({ invalidValue }) => {
+                // Arrange
+                let hasError = false;
+                const callback = () => {}; // placeholder
+                const duration = faker.random.number({ max: 5 });
+
+                // Act
+                try {
+                    await js.waitFor(() => {}, invalidValue, duration);
+                } catch (e) {
+                    hasError = true;
+                }
+
+                // Assert
+                expect(hasError).toBeTrue();
+            }
+        );
+
+        test("when duration less than or equal to 0, callback immediately invoked", async () => {
+            // Arrange
+            const duration = faker.random.number({ min: -10, max: 0 });
+            let elapsedTime = 0;
+            const interval = 10;
+
+            // Act
+            const result = await js.waitFor(
+                (elapsed) => {
+                    elapsedTime = elapsed;
+                    return true;
+                },
+                interval,
+                duration
+            );
+
+            // Assert
+            expect(elapsedTime).toBe(0);
+        });
+
+        test("when callback returns true, finishes without timeout", async () => {
+            // Arrange
+            const duration = 10;
+            const interval = 1;
+            let callbackCount = 0;
+            const callback = () => {
+                callbackCount++;
+                return true; // <------ should cause waiting to finish
+            };
+            let isTimeout = false;
+
+            // Act
+            const result = await js.waitFor(
+                callback,
+                interval,
+                duration,
+                function timeout() {
+                    isTimeout = true;
+                }
+            );
+
+            // Assert
+            expect(callbackCount).toBe(1);
+            expect(isTimeout).toBeFalse();
+        });
+
+        test("when callback returns false, calls timeout", async () => {
+            // Arrange
+            const duration = 10;
+            const interval = 2;
+            let callbackCount = 0;
+            const callback = () => {
+                callbackCount++;
+                return false; // <------ should never finish
+            };
+            let isTimeout = false;
+
+            // Act
+            const result = await js.waitFor(
+                callback,
+                interval,
+                duration,
+                function timeout() {
+                    isTimeout = true;
+                }
+            );
+
+            // Assert
+            expect(callbackCount).toBeGreaterThanOrEqual(
+                duration / interval - 1 // give it a little padding so we don't mistakenly error for runtime variability
+            );
+            expect(isTimeout).toBeTrue();
+        });
+    });
+
+    // #endregion waitFor
+});
+
+// #endregion Tests

--- a/modules/js.test.js
+++ b/modules/js.test.js
@@ -171,7 +171,7 @@ describe("js", () => {
 
             // Assert
             expect(callbackCount).toBeGreaterThanOrEqual(
-                duration / interval - 1 // give it a little padding so we don't mistakenly error for runtime variability
+                2 // give it a little padding so we don't mistakenly error for runtime variability
             );
             expect(isTimeout).toBeTrue();
         });

--- a/modules/js.test.js
+++ b/modules/js.test.js
@@ -16,39 +16,6 @@ const testUtils = require("../tests/test-utils");
 
 describe("js", () => {
     // -----------------------------------------------------------------------------------------
-    // #region sleep
-    // -----------------------------------------------------------------------------------------
-
-    describe("sleep", () => {
-        test("when milliseconds less than or equal to 0, resolves immediately", async () => {
-            // Arrange
-            const startTime = new Date();
-
-            // Act
-            await js.sleep(faker.random.number({ min: -500, max: 0 }));
-
-            // Assert
-            const elapsed = new Date() - startTime;
-            expect(elapsed).toBeLessThanOrEqual(10); // pad timing a tad so avoid failures for generally slower execution
-        });
-
-        test("execution is paused for milliseconds provided", async () => {
-            // Arrange
-            const expectedDuration = faker.random.number({ min: 1, max: 500 });
-            const startTime = new Date();
-
-            // Act
-            await js.sleep(expectedDuration);
-
-            // Assert
-            const elapsed = new Date() - startTime;
-            expect(elapsed).toBeGreaterThanOrEqual(expectedDuration);
-        });
-    });
-
-    // #endregion sleep
-
-    // -----------------------------------------------------------------------------------------
     // #region waitFor
     // -----------------------------------------------------------------------------------------
 

--- a/modules/js.test.js
+++ b/modules/js.test.js
@@ -138,7 +138,7 @@ describe("js", () => {
 
             // Assert
             expect(callbackCount).toBeGreaterThanOrEqual(
-                2 // give it a little padding so we don't mistakenly error for runtime variability
+                1 // give it a little padding so we don't mistakenly error for runtime variability
             );
             expect(isTimeout).toBeTrue();
         });


### PR DESCRIPTION
If enabled (via `-f|--fork` flag), workspace command will guide the user through configuring their github auth and then automatically create forks for each of the mainline AndcultureCode repos.

From there, being we have auto cloning of the workspace, it proceeds to then automatically clone those new forks into their workspace. 

Marry this with @brandongregoryscott new custom project CLIs, if one were to setup a custom cli at the top of their workspace, they could make their own workspace a global plugin in and of itself... for easy management (just sayin')

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
