### PR TITLE
Add/remove topics to repository

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -220,8 +220,12 @@ Various commands to interact with github andculture related resources.
 
 ### Commands
 
--   `and-cli github` - Lists master AndcultureCode repositories
--   `and-cli github -u|--username <username>` - Lists master AndcultureCode repositories as well as those for the supplied github username
+-   `and-cli github -l|--list-repos` - Lists main AndcultureCode repositories
+-   `and-cli github --list-topics --repo AndcultureCode.Cli` - Lists topics for a specified AndcultureCode repo
+-   `and-cli github --add-topic hacktoberfest --repo AndcultureCode.Cli` - Adds a topic to a specified AndcultureCodeRepo
+-   `and-cli github --remove-topic hacktoberfest --repo AndcultureCode.Cli` - Removes a topic from a specified AndcultureCode repo
+-   `and-cli github --remove-topic hacktoberfest` - Removes a topic from all AndcultureCode repos
+-   `and-cli github -u|--username <username>` - Lists forked AndcultureCode repositories for the supplied github username
 
 ## nuget
 

--- a/and-cli-github.js
+++ b/and-cli-github.js
@@ -16,8 +16,13 @@ require("./command-runner").run(async () => {
     program
         .usage("option")
         .description(github.description())
-        .option("-t, --get-topics <repo>", "Repository name to list topics for")
-        .option("-r, --repos", "Lists all andculture repos")
+        .option("-a, --add-topic <topic>", "Add topic to specified repository")
+        .option("-l, --list-repos", "Lists all andculture repos")
+        .option(
+            "-r, --repo <repo>",
+            "Repository name to act on (used in conjunction with -a or -t, for example)"
+        )
+        .option("-t, --get-topics", "List topics for a given repo")
         .option(
             "-u, --username <username>",
             "Github username for which to list andculture repositories"
@@ -25,9 +30,10 @@ require("./command-runner").run(async () => {
         .parse(process.argv);
 
     // Configure github module based on passed in args/options
-    if (program.repos != null) {
+    if (program.listRepos != null) {
         echo.success("AndcultureCode Repositories");
         echo.byProperty(await github.repositoriesByAndculture(), "url");
+        return;
     }
 
     if (program.username != null) {
@@ -36,16 +42,28 @@ require("./command-runner").run(async () => {
             await github.repositoriesByAndculture(program.username),
             "url"
         );
+        return;
     }
 
-    if (program.getTopics != null) {
-        const repoName = program.getTopics;
+    if (program.getTopics != null && program.repo != null) {
+        const repoName = program.repo;
         echo.message(`Topics for ${repoName}`);
         const topicsResult = await github.topicsForRepository(
             "andculturecode",
             repoName
         );
         echo.messages(topicsResult);
+    }
+
+    if (program.addTopic != null && program.repo != null) {
+        const topic = program.addTopic;
+        const repoName = program.repo;
+        await github.addTopicToRepository(topic, repoName);
+    }
+
+    if (program.addTopic != null && program.repo == null) {
+        const topic = program.addTopic;
+        await github.addTopicToAllRepositories(topic);
     }
 
     // #endregion Entrypoint

--- a/and-cli-github.js
+++ b/and-cli-github.js
@@ -58,12 +58,21 @@ require("./command-runner").run(async () => {
     if (program.addTopic != null && program.repo != null) {
         const topic = program.addTopic;
         const repoName = program.repo;
-        await github.addTopicToRepository(topic, repoName);
+        await github.addTopicToRepository(
+            topic,
+            github.andcultureOrg,
+            repoName
+        );
     }
 
     if (program.addTopic != null && program.repo == null) {
         const topic = program.addTopic;
         await github.addTopicToAllRepositories(topic);
+    }
+
+    // If no options are passed in, output help
+    if (process.argv.slice(2).length === 0) {
+        program.outputHelp();
     }
 
     // #endregion Entrypoint

--- a/and-cli-github.js
+++ b/and-cli-github.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
+
 require("./command-runner").run(async () => {
     // -----------------------------------------------------------------------------------------
     // #region Imports
     // -----------------------------------------------------------------------------------------
+
+    const { StringUtils } = require("andculturecode-javascript-core");
     const echo = require("./modules/echo");
     const github = require("./modules/github");
     const program = require("commander");
@@ -16,13 +19,14 @@ require("./command-runner").run(async () => {
     program
         .usage("option")
         .description(github.description())
-        .option("-a, --add-topic <topic>", "Add topic to specified repository")
+        .option("--add-topic <topic>", "Add topic to specified repository")
         .option("-l, --list-repos", "Lists all andculture repos")
+        .option("--remove-topic <topic>", "Add topic to specified repository")
         .option(
             "-r, --repo <repo>",
-            "Repository name to act on (used in conjunction with -a or -t, for example)"
+            "Repository name to act on (used in conjunction with --add-topic or --get-topics, for example)"
         )
-        .option("-t, --get-topics", "List topics for a given repo")
+        .option("--get-topics", "List topics for a given repo")
         .option(
             "-u, --username <username>",
             "Github username for which to list andculture repositories"
@@ -49,25 +53,39 @@ require("./command-runner").run(async () => {
         const repoName = program.repo;
         echo.message(`Topics for ${repoName}`);
         const topicsResult = await github.topicsForRepository(
-            "andculturecode",
-            repoName
-        );
-        echo.messages(topicsResult);
-    }
-
-    if (program.addTopic != null && program.repo != null) {
-        const topic = program.addTopic;
-        const repoName = program.repo;
-        await github.addTopicToRepository(
-            topic,
             github.andcultureOrg,
             repoName
         );
+        echo.messages(topicsResult);
+        return;
     }
 
-    if (program.addTopic != null && program.repo == null) {
-        const topic = program.addTopic;
-        await github.addTopicToAllRepositories(topic);
+    if (program.addTopic != null) {
+        if (StringUtils.isEmpty(program.repo)) {
+            await github.addTopicToAllRepositories(program.addTopic);
+            return;
+        }
+
+        await github.addTopicToRepository(
+            program.addTopic,
+            github.andcultureOrg,
+            program.repo
+        );
+        return;
+    }
+
+    if (program.removeTopic != null) {
+        if (StringUtils.isEmpty(program.repo)) {
+            await github.removeTopicFromAllRepositories(program.removeTopic);
+            return;
+        }
+
+        await github.removeTopicFromRepository(
+            program.removeTopic,
+            github.andcultureOrg,
+            program.repo
+        );
+        return;
     }
 
     // If no options are passed in, output help

--- a/and-cli-github.js
+++ b/and-cli-github.js
@@ -20,13 +20,16 @@ require("./command-runner").run(async () => {
         .usage("option")
         .description(github.description())
         .option("--add-topic <topic>", "Add topic to specified repository")
+        .option("--get-topics", "List topics for a given repo")
         .option("-l, --list-repos", "Lists all andculture repos")
-        .option("--remove-topic <topic>", "Add topic to specified repository")
+        .option(
+            "--remove-topic <topic>",
+            "Remove topic from specified repository"
+        )
         .option(
             "-r, --repo <repo>",
             "Repository name to act on (used in conjunction with --add-topic or --get-topics, for example)"
         )
-        .option("--get-topics", "List topics for a given repo")
         .option(
             "-u, --username <username>",
             "Github username for which to list andculture repositories"

--- a/and-cli-github.js
+++ b/and-cli-github.js
@@ -6,12 +6,21 @@ require("./command-runner").run(async () => {
     // -----------------------------------------------------------------------------------------
 
     const { StringUtils } = require("andculturecode-javascript-core");
+    const constants = require("./modules/constants");
     const echo = require("./modules/echo");
     const github = require("./modules/github");
     const js = require("./modules/js");
     const program = require("commander");
 
     // #endregion Imports
+
+    // -----------------------------------------------------------------------------------------
+    // #region Constants
+    // -----------------------------------------------------------------------------------------
+
+    const { ANDCULTURE_CODE } = constants;
+
+    // #endregion Constants
 
     // -----------------------------------------------------------------------------------------
     // #region Entrypoint
@@ -22,16 +31,16 @@ require("./command-runner").run(async () => {
         .description(github.description())
         .option(
             "--add-topic <topic>",
-            "Add topic to specified repository, or all AndcultureCode repositories if no repo provided"
+            `Add topic to specified repository, or all ${ANDCULTURE_CODE} repositories if no repo provided`
         )
+        .option("--list-repos", "Lists all andculture repos")
         .option(
             "--list-topics",
             "List topics for a given repo (used in conjunction with --repo)"
         )
-        .option("--list-repos", "Lists all andculture repos")
         .option(
             "--remove-topic <topic>",
-            "Remove topic from specified repository, or all AndcultureCode repositories if no repo provided"
+            `Remove topic from specified repository, or all ${ANDCULTURE_CODE} repositories if no repo provided`
         )
         .option(
             "-r, --repo <repo>",
@@ -39,7 +48,7 @@ require("./command-runner").run(async () => {
         )
         .option(
             "-u, --username <username>",
-            "Github username for which to list andculture repositories"
+            `Github username for which to list ${ANDCULTURE_CODE} repositories`
         )
         .parse(process.argv);
 
@@ -67,13 +76,13 @@ require("./command-runner").run(async () => {
         StringUtils.hasValue(program.repo);
 
     if (listAndcultureRepos) {
-        echo.success("AndcultureCode Repositories");
+        echo.success(`${ANDCULTURE_CODE} Repositories`);
         echo.byProperty(await github.repositoriesByAndculture(), "url");
         return;
     }
 
     if (listReposByUser) {
-        echo.success(`${program.username} Repositories`);
+        echo.success(`${program.username}/${ANDCULTURE_CODE} Repositories`);
         echo.byProperty(
             await github.repositoriesByAndculture(program.username),
             "url"

--- a/and-cli-github.js
+++ b/and-cli-github.js
@@ -16,6 +16,8 @@ require("./command-runner").run(async () => {
     program
         .usage("option")
         .description(github.description())
+        .option("-t, --get-topics <repo>", "Repository name to list topics for")
+        .option("-r, --repos", "Lists all andculture repos")
         .option(
             "-u, --username <username>",
             "Github username for which to list andculture repositories"
@@ -23,8 +25,10 @@ require("./command-runner").run(async () => {
         .parse(process.argv);
 
     // Configure github module based on passed in args/options
-    echo.success("AndcultureCode Repositories");
-    echo.byProperty(await github.repositoriesByAndculture(), "url");
+    if (program.repos != null) {
+        echo.success("AndcultureCode Repositories");
+        echo.byProperty(await github.repositoriesByAndculture(), "url");
+    }
 
     if (program.username != null) {
         echo.success(`${program.username} Repositories`);
@@ -32,6 +36,16 @@ require("./command-runner").run(async () => {
             await github.repositoriesByAndculture(program.username),
             "url"
         );
+    }
+
+    if (program.getTopics != null) {
+        const repoName = program.getTopics;
+        echo.message(`Topics for ${repoName}`);
+        const topicsResult = await github.topicsForRepository(
+            "andculturecode",
+            repoName
+        );
+        echo.messages(topicsResult);
     }
 
     // #endregion Entrypoint

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -2,6 +2,12 @@
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
+/** Constant to hold the company name, as it is generally cased */
+module.exports.ANDCULTURE = "andculture";
+
+/** Constant to hold the company OSS brand, as it is generally cased */
+module.exports.ANDCULTURE_CODE = "AndcultureCode";
+
 /** Constant to hold a reference to name of the CLI so we aren't hard-coding it multiple places */
 module.exports.CLI_NAME = "and-cli";
 

--- a/modules/echo.js
+++ b/modules/echo.js
@@ -12,8 +12,8 @@ const shell = require("shelljs");
 // #region Variables
 // -----------------------------------------------------------------------------------------
 
-const columnLength = 65;
 const { purple, green, red, yellow } = formatters;
+const columnLength = 65;
 const prefix = purple(`[${constants.CLI_NAME}]`);
 
 // #endregion Variables
@@ -70,16 +70,12 @@ const echo = {
     headerSuccess(message) {
         _header(() => this.success(message));
     },
-    message(message, includePrefix = true) {
-        shell.echo(includePrefix ? `${prefix} ${message}` : message);
-    },
-    messages(messages, includePrefix = true) {
-        messages.forEach((message) => this.message(message, includePrefix));
+    message(message) {
+        shell.echo(`${prefix} ${message}`);
     },
     newLine(includePrefix) {
         shell.echo(includePrefix ? prefix : "");
     },
-    sdkString: purple("[and-cli]"),
     success(message) {
         message = `${prefix} ${green(message)}`;
 

--- a/modules/echo.js
+++ b/modules/echo.js
@@ -14,6 +14,7 @@ const shell = require("shelljs");
 
 const columnLength = 65;
 const { purple, green, red, yellow } = formatters;
+const prefix = purple(`[${constants.CLI_NAME}]`);
 
 // #endregion Variables
 
@@ -42,17 +43,17 @@ const echo = {
     center(message) {
         const halfLength = (columnLength - message.length) / 2;
         if (halfLength < 0) {
-            shell.echo(`${this.sdkString} ${message}`);
+            shell.echo(`${prefix} ${message}`);
             return;
         }
-        shell.echo(`${this.sdkString} ${" ".repeat(halfLength)}${message}`);
+        shell.echo(`${prefix} ${" ".repeat(halfLength)}${message}`);
     },
     divider() {
-        shell.echo(`${this.sdkString} ${"-".repeat(columnLength)}`);
+        shell.echo(`${prefix} ${"-".repeat(columnLength)}`);
     },
     error(message) {
         shell.echo(
-            `${this.sdkString} ${red(constants.ERROR_OUTPUT_STRING)} ${message}`
+            `${prefix} ${red(constants.ERROR_OUTPUT_STRING)} ${message}`
         );
     },
     errors(messages) {
@@ -69,15 +70,18 @@ const echo = {
     headerSuccess(message) {
         _header(() => this.success(message));
     },
-    message(message) {
-        shell.echo(`${this.sdkString} ${message}`);
+    message(message, includePrefix = true) {
+        shell.echo(includePrefix ? `${prefix} ${message}` : message);
+    },
+    messages(messages, includePrefix = true) {
+        messages.forEach((message) => this.message(message, includePrefix));
     },
     newLine(includePrefix) {
-        shell.echo(includePrefix ? this.sdkString : "");
+        shell.echo(includePrefix ? prefix : "");
     },
     sdkString: purple("[and-cli]"),
     success(message) {
-        message = `${this.sdkString} ${green(message)}`;
+        message = `${prefix} ${green(message)}`;
 
         shell.echo(message);
 
@@ -85,9 +89,7 @@ const echo = {
     },
     warn(message) {
         shell.echo(
-            `${this.sdkString} ${yellow(
-                constants.WARN_OUTPUT_STRING
-            )} ${message}`
+            `${prefix} ${yellow(constants.WARN_OUTPUT_STRING)} ${message}`
         );
     },
 };

--- a/modules/github.js
+++ b/modules/github.js
@@ -100,11 +100,6 @@ const github = {
             repoName
         );
 
-        // If nothing came back from the update, an error message should already have been displayed.
-        if (updateResult == null) {
-            return null;
-        }
-
         _outputUpdateTopicResult(repoName, updateResult);
         return updateResult;
     },
@@ -335,11 +330,6 @@ const github = {
             repoName
         );
 
-        // If nothing came back from the update, an error message should already have been displayed.
-        if (updateResult == null) {
-            return null;
-        }
-
         _outputUpdateTopicResult(repoName, updateResult);
         return updateResult;
     },
@@ -481,9 +471,14 @@ const _list = async (command, options, filter) => {
  * Outputs information for a topic update operation
  *
  * @param {string} repoName short name of repository (excluding user/organization)
- * @param {string[]} result Result to concatenate topic names from
+ * @param {string[] | undefined} result Result to concatenate topic names from
  */
 const _outputUpdateTopicResult = (repoName, result) => {
+    // If nothing came back from the update, an error message should already have been displayed.
+    if (result == null) {
+        return;
+    }
+
     echo.success(`Updated topics for ${repoName}`);
     echo.message(result.join(", "));
 };

--- a/modules/github.js
+++ b/modules/github.js
@@ -336,7 +336,8 @@ const github = {
 
     /**
      * Lists all andculture organization repositories
-     * @param {string} username optional username of user account. if null, returns master andculture organization repositories
+     * @param {string} username optional username of user account. if null, returns main andculture
+     * organization repositories
      */
     async repositoriesByAndculture(username) {
         const fn =

--- a/modules/github.js
+++ b/modules/github.js
@@ -48,6 +48,7 @@ const github = {
     andcultureOrg: "AndcultureCode",
     apiRepositoriesRouteParam: "repos",
     apiRootUrl: `https://${API_DOMAIN}`,
+    apiTopicsRouteParam: "topics",
     configAuthConfigPath: upath.join(os.homedir(), ".netrc"), // Path to octokit-auth-netrc configuration
     configAuthDocsUrl:
         "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token",
@@ -88,7 +89,7 @@ const github = {
      */
     async addTopicToRepository(topic, owner, repoName) {
         if (!_validateTopicInputOrExit(topic, owner, repoName)) {
-            return false;
+            return null;
         }
 
         const updateFunction = (existingTopics) => [...existingTopics, topic];
@@ -101,11 +102,11 @@ const github = {
 
         // If nothing came back from the update, an error message should already have been displayed.
         if (updateResult == null) {
-            return false;
+            return null;
         }
 
         _outputUpdateTopicResult(repoName, updateResult);
-        return true;
+        return updateResult;
     },
 
     /**
@@ -322,7 +323,7 @@ const github = {
      */
     async removeTopicFromRepository(topic, owner, repoName) {
         if (!_validateTopicInputOrExit(topic, owner, repoName)) {
-            return false;
+            return null;
         }
 
         const updateFunction = (existingTopics) =>
@@ -336,11 +337,11 @@ const github = {
 
         // If nothing came back from the update, an error message should already have been displayed.
         if (updateResult == null) {
-            return false;
+            return null;
         }
 
         _outputUpdateTopicResult(repoName, updateResult);
-        return true;
+        return updateResult;
     },
 
     /**

--- a/modules/github.js
+++ b/modules/github.js
@@ -5,6 +5,7 @@
 const { createNetrcAuth } = require("octokit-auth-netrc");
 const { Octokit } = require("@octokit/rest");
 const { StringUtils } = require("andculturecode-javascript-core");
+const constants = require("./constants");
 const echo = require("./echo");
 const formatters = require("./formatters");
 const fs = require("fs");
@@ -21,6 +22,7 @@ const userPrompt = require("./user-prompt");
 // #region Constants
 // -----------------------------------------------------------------------------------------
 
+const { ANDCULTURE, ANDCULTURE_CODE } = constants;
 const { yellow } = formatters;
 const API_DOMAIN = "api.github.com";
 
@@ -45,7 +47,7 @@ const github = {
     // #region Public Properties
     // -----------------------------------------------------------------------------------------
 
-    andcultureOrg: "AndcultureCode",
+    andcultureOrg: ANDCULTURE_CODE,
     apiRepositoriesRouteParam: "repos",
     apiRootUrl: `https://${API_DOMAIN}`,
     apiTopicsRouteParam: "topics",
@@ -66,6 +68,11 @@ const github = {
      * @param {string} topic Topic to be added
      */
     async addTopicToAllRepositories(topic) {
+        if (StringUtils.isEmpty(topic)) {
+            echo.error("Topic name is required");
+            return;
+        }
+
         const andcultureRepos = await this.repositoriesByAndculture();
         const repoNames = andcultureRepos.map((e) => e.name);
 
@@ -122,7 +129,7 @@ const github = {
     },
 
     description() {
-        return `Helpful github operations used at andculture`;
+        return `Helpful github operations used at ${ANDCULTURE}`;
     },
 
     /**
@@ -291,6 +298,11 @@ const github = {
      * @param {string} topic Topic to be removed
      */
     async removeTopicFromAllRepositories(topic) {
+        if (StringUtils.isEmpty(topic)) {
+            echo.error("Topic name is required");
+            return;
+        }
+
         const andcultureRepos = await this.repositoriesByAndculture();
         const repoNames = andcultureRepos.map((e) => e.name);
 

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -41,12 +41,6 @@ describe("github", () => {
             ].join("/")
         );
 
-    afterEach(() => {
-        // Clean all mocked API routes - some tests in here actually call the Github API, and will
-        // flake out depending on ordering.
-        nock.cleanAll();
-    });
-
     // #endregion Setup
 
     // -----------------------------------------------------------------------------------------
@@ -322,11 +316,7 @@ describe("github", () => {
             const expected = "wintondeshong";
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ url: `https://someurl.com/${expected}` }]);
 
             // Act
@@ -344,11 +334,7 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        username + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(username)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             const filter = (repos) =>
@@ -375,11 +361,7 @@ describe("github", () => {
             const expected = github.andcultureOrg;
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -397,11 +379,7 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        username + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             // Act
@@ -425,11 +403,7 @@ describe("github", () => {
             const expected = github.andcultureOrg;
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -445,11 +419,7 @@ describe("github", () => {
             const expected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -466,11 +436,7 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             const filter = (repos) =>

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -41,6 +41,12 @@ describe("github", () => {
             ].join("/")
         );
 
+    afterEach(() => {
+        // Clean all mocked API routes - some tests in here actually call the Github API, and will
+        // flake out depending on ordering.
+        nock.cleanAll();
+    });
+
     // #endregion Setup
 
     // -----------------------------------------------------------------------------------------
@@ -316,7 +322,11 @@ describe("github", () => {
             const expected = "wintondeshong";
 
             nock(github.apiRootUrl)
-                .get(getReposRoute(expected)) // make sure github is properly passed username
+                .get(
+                    new RegExp(
+                        expected + "/" + github.apiRepositoriesRouteParam
+                    )
+                ) // make sure github is properly passed username
                 .reply(200, [{ url: `https://someurl.com/${expected}` }]);
 
             // Act
@@ -334,7 +344,11 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(getReposRoute(username)) // make sure github is properly passed username
+                .get(
+                    new RegExp(
+                        username + "/" + github.apiRepositoriesRouteParam
+                    )
+                ) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             const filter = (repos) =>
@@ -361,7 +375,11 @@ describe("github", () => {
             const expected = github.andcultureOrg;
 
             nock(github.apiRootUrl)
-                .get(getReposRoute(expected)) // make sure github is properly passed username
+                .get(
+                    new RegExp(
+                        expected + "/" + github.apiRepositoriesRouteParam
+                    )
+                ) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -379,7 +397,11 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(getReposRoute(expected)) // make sure github is properly passed username
+                .get(
+                    new RegExp(
+                        username + "/" + github.apiRepositoriesRouteParam
+                    )
+                ) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             // Act
@@ -403,7 +425,11 @@ describe("github", () => {
             const expected = github.andcultureOrg;
 
             nock(github.apiRootUrl)
-                .get(getReposRoute(expected)) // make sure github is properly passed username
+                .get(
+                    new RegExp(
+                        expected + "/" + github.apiRepositoriesRouteParam
+                    )
+                ) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -419,7 +445,11 @@ describe("github", () => {
             const expected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(getReposRoute(expected)) // make sure github is properly passed username
+                .get(
+                    new RegExp(
+                        expected + "/" + github.apiRepositoriesRouteParam
+                    )
+                ) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -436,7 +466,11 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(getReposRoute(expected)) // make sure github is properly passed username
+                .get(
+                    new RegExp(
+                        expected + "/" + github.apiRepositoriesRouteParam
+                    )
+                ) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             const filter = (repos) =>

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -55,6 +55,7 @@ describe("github", () => {
             const addTopicSpy = jest
                 .spyOn(github, "addTopicToRepository")
                 .mockImplementation(() => []);
+            // Mock the confirmation prompt since we do not have user input
             jest.spyOn(userPrompt, "confirmOrExit").mockResolvedValueOnce();
 
             // Act

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -138,6 +138,11 @@ describe("github", () => {
                 const existingTopics = [testUtils.randomWord()];
                 const expectedTopics = [...existingTopics, topic];
 
+                // We'll want to mock the token so that CI environments aren't left hanging
+                jest.spyOn(github, "getToken").mockReturnValue(
+                    testUtils.randomWord()
+                );
+
                 // Mock the call to get existing topics
                 nock(github.apiRootUrl)
                     .get(getRepoTopicsRoute(owner, repoName))
@@ -563,6 +568,11 @@ describe("github", () => {
                 const repoName = testUtils.randomWord();
                 const existingTopics = [topic];
                 const expectedTopics = [];
+
+                // We'll want to mock the token so that CI environments aren't left hanging
+                jest.spyOn(github, "getToken").mockReturnValue(
+                    testUtils.randomWord()
+                );
 
                 // Mock the call to get existing topics
                 nock(github.apiRootUrl)

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -8,6 +8,7 @@ const fs = require("fs");
 const github = require("./github");
 const nock = require("nock");
 const testUtils = require("../tests/test-utils");
+const echo = require("./echo");
 
 // #endregion Imports
 
@@ -16,6 +17,22 @@ const testUtils = require("../tests/test-utils");
 // -----------------------------------------------------------------------------------------
 
 describe("github", () => {
+    // -----------------------------------------------------------------------------------------
+    // #region addTopicToAllRepositories
+    // -----------------------------------------------------------------------------------------
+
+    describe("addTopicToAllRepositories", () => {});
+
+    // #endregion addTopicToAllRepositories
+
+    // -----------------------------------------------------------------------------------------
+    // #region addTopicToRepository
+    // -----------------------------------------------------------------------------------------
+
+    describe("addTopicToRepository", () => {});
+
+    // #endregion addTopicToRepository
+
     // -----------------------------------------------------------------------------------------
     // #region configureToken
     // -----------------------------------------------------------------------------------------
@@ -321,6 +338,160 @@ describe("github", () => {
     });
 
     // #endregion repositoriesByAndculture
+
+    // -----------------------------------------------------------------------------------------
+    // #region topicsForRepository
+    // -----------------------------------------------------------------------------------------
+
+    describe("topicsForRepository", () => {
+        test.each([undefined, null, "", " "])(
+            "given owner is %p, it outputs an error and returns undefined",
+            async (owner) => {
+                // Arrange
+                const repoName = testUtils.randomWord();
+                const echoErrorSpy = jest.spyOn(echo, "error");
+
+                // Act
+                const result = await github.topicsForRepository(
+                    owner,
+                    repoName
+                );
+
+                // Assert
+                expect(echoErrorSpy).toHaveBeenCalled();
+                expect(result).toBeUndefined();
+            }
+        );
+
+        test.each([undefined, null, "", " "])(
+            "given repoName is %p, it outputs an error and returns undefined",
+            async (repoName) => {
+                // Arrange
+                const owner = testUtils.randomWord();
+                const echoErrorSpy = jest.spyOn(echo, "error");
+
+                // Act
+                const result = await github.topicsForRepository(
+                    owner,
+                    repoName
+                );
+
+                // Assert
+                expect(echoErrorSpy).toHaveBeenCalled();
+                expect(result).toBeUndefined();
+            }
+        );
+
+        test("given an owner and repoName, it returns an array of topic names", async () => {
+            // Arrange
+            const owner = testUtils.randomWord();
+            const repoName = testUtils.randomWord();
+            const expectedTopics = [
+                testUtils.randomWord(),
+                testUtils.randomWord(),
+            ];
+            const mockTopicRoute = [
+                github.apiRepositoriesRouteParam,
+                owner,
+                repoName,
+                "topics",
+            ].join("/");
+
+            nock(github.apiRootUrl)
+                .get(new RegExp(mockTopicRoute))
+                .reply(200, { names: expectedTopics });
+
+            // Act
+            const result = await github.topicsForRepository(owner, repoName);
+
+            // Assert
+            expect(result).toStrictEqual(expectedTopics);
+        });
+
+        test("given an owner and repoName, when response.data is null, it outputs an error and returns undefined", async () => {
+            // Arrange
+            const owner = testUtils.randomWord();
+            const repoName = testUtils.randomWord();
+            const echoErrorSpy = jest.spyOn(echo, "error");
+            const responseData = null; // This is the important setup
+
+            const mockTopicRoute = [
+                github.apiRepositoriesRouteParam,
+                owner,
+                repoName,
+                "topics",
+            ].join("/");
+
+            nock(github.apiRootUrl)
+                .get(new RegExp(mockTopicRoute))
+                .reply(200, responseData);
+
+            // Act
+            const result = await github.topicsForRepository(owner, repoName);
+
+            // Assert
+            expect(echoErrorSpy).toHaveBeenCalled();
+            expect(result).toBeUndefined();
+        });
+
+        test("given an owner and repoName, when response.status < 200, it outputs an error and returns undefined", async () => {
+            // Arrange
+            const owner = testUtils.randomWord();
+            const repoName = testUtils.randomWord();
+            const responseStatus = testUtils.randomNumber(0, 199); // This is the important setup
+            const responseData = null;
+
+            const echoErrorSpy = jest.spyOn(echo, "error");
+
+            const mockTopicRoute = [
+                github.apiRepositoriesRouteParam,
+                owner,
+                repoName,
+                "topics",
+            ].join("/");
+
+            nock(github.apiRootUrl)
+                .get(new RegExp(mockTopicRoute))
+                .reply(responseStatus, responseData);
+
+            // Act
+            const result = await github.topicsForRepository(owner, repoName);
+
+            // Assert
+            expect(echoErrorSpy).toHaveBeenCalled();
+            expect(result).toBeUndefined();
+        });
+
+        test("given an owner and repoName, when response.status > 202, it outputs an error and returns undefined", async () => {
+            // Arrange
+            const owner = testUtils.randomWord();
+            const repoName = testUtils.randomWord();
+            const responseStatus = testUtils.randomNumber(203); // This is the important setup
+            const responseData = null;
+
+            const echoErrorSpy = jest.spyOn(echo, "error");
+
+            const mockTopicRoute = [
+                github.apiRepositoriesRouteParam,
+                owner,
+                repoName,
+                "topics",
+            ].join("/");
+
+            nock(github.apiRootUrl)
+                .get(new RegExp(mockTopicRoute))
+                .reply(responseStatus, responseData);
+
+            // Act
+            const result = await github.topicsForRepository(owner, repoName);
+
+            // Assert
+            expect(echoErrorSpy).toHaveBeenCalled();
+            expect(result).toBeUndefined();
+        });
+    });
+
+    // #endregion topicsForRepository
 });
 
 // #endregion Tests

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -349,7 +349,7 @@ describe("github", () => {
     // -----------------------------------------------------------------------------------------
 
     describe("repositoriesByAndculture", () => {
-        test(`given no username, returns list of master ${github.andcultureOrg} repositories`, async () => {
+        test(`given no username, returns list of main ${github.andcultureOrg} repositories`, async () => {
             // Arrange
             const expected = github.andcultureOrg;
 
@@ -399,7 +399,7 @@ describe("github", () => {
     // -----------------------------------------------------------------------------------------
 
     describe("repositoriesByOrganization", () => {
-        test(`given no organization, returns list of master ${github.andcultureOrg} repositories`, async () => {
+        test(`given no organization, returns list of main ${github.andcultureOrg} repositories`, async () => {
             // Arrange
             const expected = github.andcultureOrg;
 
@@ -419,7 +419,7 @@ describe("github", () => {
             expect(results[0].name).toBe(expected);
         });
 
-        test(`given organization, returns list of master ${github.andcultureOrg} repositories`, async () => {
+        test(`given organization, returns list of main ${github.andcultureOrg} repositories`, async () => {
             // Arrange
             const expected = testUtils.randomWord();
 
@@ -439,7 +439,7 @@ describe("github", () => {
             expect(results[0].name).toBe(expected);
         });
 
-        test(`given filter, returns list of master ${github.andcultureOrg} repositories matched by filter`, async () => {
+        test(`given filter, returns list of main ${github.andcultureOrg} repositories matched by filter`, async () => {
             // Arrange
             const expected = github.andcultureOrg;
             const unexpected = testUtils.randomWord();

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -69,7 +69,7 @@ describe("github", () => {
 
             const addTopicSpy = jest
                 .spyOn(github, "addTopicToRepository")
-                .mockImplementation(() => []);
+                .mockResolvedValue([]);
 
             // Mock the confirmation prompt since we do not have user input
             jest.spyOn(userPrompt, "confirmOrExit").mockResolvedValueOnce();
@@ -510,7 +510,7 @@ describe("github", () => {
 
             const removeTopicSpy = jest
                 .spyOn(github, "removeTopicFromRepository")
-                .mockImplementation(() => []);
+                .mockResolvedValue([]);
 
             // Mock the confirmation prompt since we do not have user input
             jest.spyOn(userPrompt, "confirmOrExit").mockResolvedValueOnce();

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -322,11 +322,7 @@ describe("github", () => {
             const expected = "wintondeshong";
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ url: `https://someurl.com/${expected}` }]);
 
             // Act
@@ -344,11 +340,7 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        username + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(username)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             const filter = (repos) =>
@@ -375,11 +367,7 @@ describe("github", () => {
             const expected = github.andcultureOrg;
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -397,11 +385,7 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        username + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(username)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             // Act
@@ -425,11 +409,7 @@ describe("github", () => {
             const expected = github.andcultureOrg;
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -445,11 +425,7 @@ describe("github", () => {
             const expected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }]);
 
             // Act
@@ -466,11 +442,7 @@ describe("github", () => {
             const unexpected = testUtils.randomWord();
 
             nock(github.apiRootUrl)
-                .get(
-                    new RegExp(
-                        expected + "/" + github.apiRepositoriesRouteParam
-                    )
-                ) // make sure github is properly passed username
+                .get(getReposRoute(expected)) // make sure github is properly passed username
                 .reply(200, [{ name: expected }, { name: unexpected }]);
 
             const filter = (repos) =>

--- a/modules/github.test.js
+++ b/modules/github.test.js
@@ -23,6 +23,12 @@ describe("github", () => {
     // -----------------------------------------------------------------------------------------
 
     /**
+     * Utility function for generating the /{owner}/repos API route
+     */
+    const getReposRoute = (owner) =>
+        new RegExp(`${owner}/${github.apiRepositoriesRouteParam}`);
+
+    /**
      * Utility function for generating the /repos/{owner}/{repoName}/topics API route
      */
     const getRepoTopicsRoute = (owner, repoName) =>
@@ -50,11 +56,21 @@ describe("github", () => {
     describe("addTopicToAllRepositories", () => {
         test(`it calls addTopicToRepository for each ${github.andcultureOrg} repo`, async () => {
             // Arrange
-            const repositories = await github.repositoriesByAndculture();
             const topic = testUtils.randomWord();
+            const repos = [
+                { name: "AndcultureCode.Cli" },
+                { name: "AndcultureCode.CSharp.Core" },
+            ];
+
+            // Mock the API response for repositories
+            nock(github.apiRootUrl)
+                .get(getReposRoute(github.andcultureOrg))
+                .reply(200, repos);
+
             const addTopicSpy = jest
                 .spyOn(github, "addTopicToRepository")
                 .mockImplementation(() => []);
+
             // Mock the confirmation prompt since we do not have user input
             jest.spyOn(userPrompt, "confirmOrExit").mockResolvedValueOnce();
 
@@ -62,7 +78,7 @@ describe("github", () => {
             await github.addTopicToAllRepositories(topic);
 
             // Assert
-            expect(addTopicSpy).toHaveBeenCalledTimes(repositories.length);
+            expect(addTopicSpy).toHaveBeenCalledTimes(repos.length);
         });
     });
 
@@ -481,11 +497,21 @@ describe("github", () => {
     describe("removeTopicFromAllRepositories", () => {
         test(`it calls removeTopicFromRepository for each ${github.andcultureOrg} repo`, async () => {
             // Arrange
-            const repositories = await github.repositoriesByAndculture();
             const topic = testUtils.randomWord();
+            const repos = [
+                { name: "AndcultureCode.Cli" },
+                { name: "AndcultureCode.CSharp.Core" },
+            ];
+
+            // Mock the API response for repositories
+            nock(github.apiRootUrl)
+                .get(getReposRoute(github.andcultureOrg))
+                .reply(200, repos);
+
             const removeTopicSpy = jest
                 .spyOn(github, "removeTopicFromRepository")
                 .mockImplementation(() => []);
+
             // Mock the confirmation prompt since we do not have user input
             jest.spyOn(userPrompt, "confirmOrExit").mockResolvedValueOnce();
 
@@ -493,7 +519,7 @@ describe("github", () => {
             await github.removeTopicFromAllRepositories(topic);
 
             // Assert
-            expect(removeTopicSpy).toHaveBeenCalledTimes(repositories.length);
+            expect(removeTopicSpy).toHaveBeenCalledTimes(repos.length);
         });
     });
 

--- a/modules/user-prompt.js
+++ b/modules/user-prompt.js
@@ -24,8 +24,8 @@ const prompt = {
     /**
      * Prompts the user for confirmation, and exits if the user does not type y or Y.
      *
-     * @param {*} question Question to pose to the user
-     * @param {number} [exitStatus=0] Exit status to pass to shelljs if confirmation unsccessful
+     * @param {string} question Question to pose to the user
+     * @param {number} [exitStatus=0] Exit status to pass to shelljs if confirmation unsuccessful
      */
     async confirmOrExit(question, exitStatus = 0) {
         const prompt = this.getPrompt();
@@ -44,7 +44,7 @@ const prompt = {
      *
      */
     getPrompt() {
-        if (cachedPrompt !== undefined) {
+        if (cachedPrompt != null) {
             return cachedPrompt;
         }
 


### PR DESCRIPTION
Resolves #121 Command to update topics for AndcultureCode repositories

Adds the ability to add/remove topics for a single AndcultureCode repo or all of them at once. Relies on the same personal access token authentication that was already built in - I am assuming only those with permission to update our repo description, settings, etc. will be able to leverage these commands.

Updated the default behavior for the `github` command to require a flag before listing off any repositories, and fixed a bug where the `[and-cli]` prefix was lost in the output

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
