### PR TITLE
Feature/install command plugin update

### DIFF
--- a/and-cli-install.js
+++ b/and-cli-install.js
@@ -55,6 +55,7 @@ require("./command-runner").run(async () => {
             _installDevAlias();
 
             // Reload shell
+            echo.newLine();
             echo.success(
                 "Install successful. Reload your shell for changes to take effect"
             );
@@ -71,6 +72,11 @@ require("./command-runner").run(async () => {
         return StringUtils.hasValue(
             shell.cat(file.bashFile()).grep(text).stdout
         );
+    };
+
+    const _echoInstallErrorAndExit = (code) => {
+        echo.error(`There was an error installing the package: ${code}`);
+        shell.exit(code);
     };
 
     const _installAndCliGlobally = () => {
@@ -102,13 +108,12 @@ require("./command-runner").run(async () => {
             return;
         }
 
-        shell.echo("").toEnd(file.bashFile());
-        shell
-            .echo(
-                `# ${CLI_NAME} global development alias pointing to your fork of the repository`
-            )
-            .toEnd(file.bashFile());
-        shell.echo(developerAlias).toEnd(file.bashFile());
+        _writeToBashFile("");
+        _writeToBashFile(
+            `# ${CLI_NAME} global development alias pointing to your fork of the repository`
+        );
+        _writeToBashFile(developerAlias);
+
         echo.success(`Successfully installed ${CLI_NAME}-dev alias`);
     };
 
@@ -145,17 +150,15 @@ require("./command-runner").run(async () => {
             return;
         }
 
-        shell.echo("").toEnd(file.bashFile());
-        shell.echo(`# ${CLI_NAME} project-level alias`).toEnd(file.bashFile());
-        shell.echo(projectAlias).toEnd(file.bashFile());
+        _writeToBashFile("");
+        _writeToBashFile(`# ${CLI_NAME} project-level alias`);
+        _writeToBashFile(projectAlias);
+
         echo.success(`Successfully installed ${CLI_NAME} bash alias`);
         echo.newLine();
     };
 
-    const _echoInstallErrorAndExit = (code) => {
-        echo.error(`There was an error installing the package: ${code}`);
-        shell.exit(code);
-    };
+    const _writeToBashFile = (text) => shell.echo(text).toEnd(file.bashFile());
 
     // #endregion Private Functions
 

--- a/and-cli-install.js
+++ b/and-cli-install.js
@@ -6,10 +6,12 @@ require("./command-runner").run(async () => {
     // -----------------------------------------------------------------------------------------
 
     const { CLI_NAME, ENTRYPOINT } = require("./modules/constants");
+    const { StringUtils } = require("andculturecode-javascript-core");
     const commands = require("./modules/commands");
     const echo = require("./modules/echo");
     const file = require("./modules/file");
     const formatters = require("./modules/formatters");
+    const js = require("./modules/js");
     const packageConfig = require("./modules/package-config");
     const program = require("commander");
     const shell = require("shelljs");
@@ -39,61 +41,20 @@ require("./command-runner").run(async () => {
         run() {
             // Local project (likely a plugin CLI) global install
             const binName = packageConfig.getLocalBinName();
-            if (binName !== CLI_NAME) {
-                _installLocalProjectGlobally();
+            if (StringUtils.hasValue(binName) && binName !== CLI_NAME) {
+                _installLocalProjectGlobally(binName);
             }
 
             // Global npm package
-            echo.message(`Installing ${CLI_NAME} as global npm tool...`);
-            shell.exec(this.cmd(CLI_NAME));
-            echo.success("Successfully installed globally");
-            echo.newLine();
+            _installAndCliGlobally();
 
             // Project-specific alias
-            echo.message(
-                `Configuring project-specific '${CLI_NAME}' bash alias...`
-            );
-            const projectAlias = `alias ${CLI_NAME}='npx ${CLI_NAME}'`;
-
-            if (
-                shell.cat(file.bashFile()).grep(projectAlias).stdout.length > 1
-            ) {
-                echo.success(`${CLI_NAME} bash alias already installed`);
-            } else {
-                shell.echo("").toEnd(file.bashFile());
-                shell
-                    .echo(`# ${CLI_NAME} project-level alias`)
-                    .toEnd(file.bashFile());
-                shell.echo(projectAlias).toEnd(file.bashFile());
-                echo.success(`Successfully installed ${CLI_NAME} bash alias`);
-            }
-            echo.newLine();
+            _installNpxAlias();
 
             // Developer alias
-            echo.message(
-                `Configuring cli development '${CLI_NAME}-dev' bash alias...`
-            );
-            const pathToCli = upath.join(shell.pwd().toString(), ENTRYPOINT);
-            const developerAlias = `alias ${CLI_NAME}-dev='${pathToCli}'`;
-
-            if (
-                shell.cat(file.bashFile()).grep(developerAlias).stdout.length >
-                1
-            ) {
-                echo.success(`${CLI_NAME}-dev bash alias already installed`);
-            } else {
-                shell.echo("").toEnd(file.bashFile());
-                shell
-                    .echo(
-                        `# ${CLI_NAME} global development alias pointing to your fork of the repository`
-                    )
-                    .toEnd(file.bashFile());
-                shell.echo(developerAlias).toEnd(file.bashFile());
-                echo.success(`Successfully installed ${CLI_NAME}-dev alias`);
-            }
+            _installDevAlias();
 
             // Reload shell
-            echo.newLine();
             echo.success(
                 "Install successful. Reload your shell for changes to take effect"
             );
@@ -106,15 +67,61 @@ require("./command-runner").run(async () => {
     // #region Private Functions
     // -----------------------------------------------------------------------------------------
 
-    const _installLocalProjectGlobally = () => {
+    const _bashFileContains = (text) => {
+        return StringUtils.hasValue(
+            shell.cat(file.bashFile()).grep(text).stdout
+        );
+    };
+
+    const _installAndCliGlobally = () => {
+        const cmd = install.cmd(CLI_NAME);
+        echo.message(
+            `Installing ${CLI_NAME} as global npm tool... (via ${cmd})`
+        );
+
+        const { code } = shell.exec(cmd);
+        if (code !== 0) {
+            _echoInstallErrorAndExit(code);
+            return;
+        }
+
+        echo.success(`Successfully installed ${CLI_NAME} globally`);
+        echo.newLine();
+    };
+
+    const _installDevAlias = () => {
+        echo.message(
+            `Configuring cli development '${CLI_NAME}-dev' bash alias...`
+        );
+        const pathToCli = upath.join(shell.pwd().toString(), ENTRYPOINT);
+        const developerAlias = `alias ${CLI_NAME}-dev='${pathToCli}'`;
+
+        if (_bashFileContains(developerAlias)) {
+            echo.success(`${CLI_NAME}-dev bash alias already installed`);
+            echo.newLine();
+            return;
+        }
+
+        shell.echo("").toEnd(file.bashFile());
+        shell
+            .echo(
+                `# ${CLI_NAME} global development alias pointing to your fork of the repository`
+            )
+            .toEnd(file.bashFile());
+        shell.echo(developerAlias).toEnd(file.bashFile());
+        echo.success(`Successfully installed ${CLI_NAME}-dev alias`);
+    };
+
+    const _installLocalProjectGlobally = (binName) => {
         const cmd = install.cmd(".");
         echo.message(
             `Installing current project as a global npm tool... (via ${cmd})`
         );
+
         const { code } = shell.exec(cmd);
         if (code !== 0) {
-            echo.error(`There was an error installing the package: ${code}`);
-            shell.exit(code);
+            _echoInstallErrorAndExit(code);
+            return;
         }
 
         echo.success("Current project was successfully installed globally");
@@ -123,6 +130,31 @@ require("./command-runner").run(async () => {
                 `${binName} <command>`
             )}`
         );
+        echo.newLine();
+    };
+
+    const _installNpxAlias = () => {
+        echo.message(
+            `Configuring project-specific '${CLI_NAME}' bash alias...`
+        );
+        const projectAlias = `alias ${CLI_NAME}='npx ${CLI_NAME}'`;
+
+        if (_bashFileContains(projectAlias)) {
+            echo.success(`${CLI_NAME} bash alias already installed`);
+            echo.newLine();
+            return;
+        }
+
+        shell.echo("").toEnd(file.bashFile());
+        shell.echo(`# ${CLI_NAME} project-level alias`).toEnd(file.bashFile());
+        shell.echo(projectAlias).toEnd(file.bashFile());
+        echo.success(`Successfully installed ${CLI_NAME} bash alias`);
+        echo.newLine();
+    };
+
+    const _echoInstallErrorAndExit = (code) => {
+        echo.error(`There was an error installing the package: ${code}`);
+        shell.exit(code);
     };
 
     // #endregion Private Functions
@@ -137,7 +169,7 @@ require("./command-runner").run(async () => {
         .parse(process.argv);
 
     // If no options are passed in, performs installation steps
-    if (process.argv.slice(2).length === 0) {
+    if (js.hasNoArguments()) {
         install.run();
     }
 

--- a/and-cli-install.js
+++ b/and-cli-install.js
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
+
 require("./command-runner").run(async () => {
     // -----------------------------------------------------------------------------------------
     // #region Imports
     // -----------------------------------------------------------------------------------------
 
+    const { CLI_NAME, ENTRYPOINT } = require("./modules/constants");
     const commands = require("./modules/commands");
     const echo = require("./modules/echo");
     const file = require("./modules/file");
-    const path = require("path");
+    const formatters = require("./modules/formatters");
+    const packageConfig = require("./modules/package-config");
     const program = require("commander");
     const shell = require("shelljs");
     const upath = require("upath");
@@ -15,66 +18,78 @@ require("./command-runner").run(async () => {
     // #endregion Imports
 
     // -----------------------------------------------------------------------------------------
-    // #region Functions
+    // #region Constants
+    // -----------------------------------------------------------------------------------------
+
+    const { purple } = formatters;
+
+    // #endregion Constants
+
+    // -----------------------------------------------------------------------------------------
+    // #region Public Functions
     // -----------------------------------------------------------------------------------------
 
     const install = {
-        cmds: {
-            installGlobally: "npm install --global and-cli",
+        cmd(package) {
+            return `npm install --global ${package}`;
         },
         description() {
             return "Configures development machine with global npm, project-specific and developer and-cli tools";
         },
         run() {
+            // Local project (likely a plugin CLI) global install
+            const binName = packageConfig.getLocalBinName();
+            if (binName !== CLI_NAME) {
+                _installLocalProjectGlobally();
+            }
+
             // Global npm package
-            echo.message("Installing and-cli as global npm tool...");
-            shell.exec(this.cmds.installGlobally);
+            echo.message(`Installing ${CLI_NAME} as global npm tool...`);
+            shell.exec(this.cmd(CLI_NAME));
             echo.success("Successfully installed globally");
             echo.newLine();
 
             // Project-specific alias
             echo.message(
-                "Configuring project-specific `and-cli` bash alias..."
+                `Configuring project-specific '${CLI_NAME}' bash alias...`
             );
-            const projectAlias = "alias and-cli='npx and-cli'";
+            const projectAlias = `alias ${CLI_NAME}='npx ${CLI_NAME}'`;
 
             if (
                 shell.cat(file.bashFile()).grep(projectAlias).stdout.length > 1
             ) {
-                echo.success("and-cli bash alias already installed");
+                echo.success(`${CLI_NAME} bash alias already installed`);
             } else {
                 shell.echo("").toEnd(file.bashFile());
                 shell
-                    .echo("# and-cli project-level alias")
+                    .echo(`# ${CLI_NAME} project-level alias`)
                     .toEnd(file.bashFile());
                 shell.echo(projectAlias).toEnd(file.bashFile());
-                echo.success("Successfully installed and-cli bash alias");
+                echo.success(`Successfully installed ${CLI_NAME} bash alias`);
             }
             echo.newLine();
 
             // Developer alias
             echo.message(
-                "Configuring cli development `and-cli-dev` bash alias..."
+                `Configuring cli development '${CLI_NAME}-dev' bash alias...`
             );
-            const pathToCli = upath.toUnix(
-                path.join(shell.pwd().toString(), "and-cli.js")
-            );
-            const developerAlias = `alias and-cli-dev='${pathToCli}'`;
+            const pathToCli = upath.join(shell.pwd().toString(), ENTRYPOINT);
+            const developerAlias = `alias ${CLI_NAME}-dev='${pathToCli}'`;
 
             if (
                 shell.cat(file.bashFile()).grep(developerAlias).stdout.length >
                 1
             ) {
-                echo.success("and-cli-dev bash alias already installed");
+                echo.success(`${CLI_NAME}-dev bash alias already installed`);
             } else {
                 shell.echo("").toEnd(file.bashFile());
                 shell
                     .echo(
-                        "# and-cli global development alias pointing to your fork of the repository"
+                        `# ${CLI_NAME} global development alias pointing to your fork of the repository`
                     )
                     .toEnd(file.bashFile());
                 shell.echo(developerAlias).toEnd(file.bashFile());
-                echo.success("Successfully installed and-cli-dev alias");
+                echo.success(`Successfully installed ${CLI_NAME}-dev alias`);
             }
 
             // Reload shell
@@ -85,7 +100,32 @@ require("./command-runner").run(async () => {
         },
     };
 
-    // #endregion Functions
+    // #endregion Public Functions
+
+    // -----------------------------------------------------------------------------------------
+    // #region Private Functions
+    // -----------------------------------------------------------------------------------------
+
+    const _installLocalProjectGlobally = () => {
+        const cmd = install.cmd(".");
+        echo.message(
+            `Installing current project as a global npm tool... (via ${cmd})`
+        );
+        const { code } = shell.exec(cmd);
+        if (code !== 0) {
+            echo.error(`There was an error installing the package: ${code}`);
+            shell.exit(code);
+        }
+
+        echo.success("Current project was successfully installed globally");
+        echo.message(
+            `You should now be able to run it from any directory with: ${purple(
+                `${binName} <command>`
+            )}`
+        );
+    };
+
+    // #endregion Private Functions
 
     // -----------------------------------------------------------------------------------------
     // #region Entrypoint

--- a/and-cli-install.js
+++ b/and-cli-install.js
@@ -79,15 +79,23 @@ require("./command-runner").run(async () => {
         shell.exit(code);
     };
 
+    const _execAndExitIfErrored = (cmd) => {
+        const { code } = shell.exec(cmd);
+        if (code !== 0) {
+            _echoInstallErrorAndExit(code);
+            return false;
+        }
+
+        return true;
+    };
+
     const _installAndCliGlobally = () => {
         const cmd = install.cmd(CLI_NAME);
         echo.message(
             `Installing ${CLI_NAME} as global npm tool... (via ${cmd})`
         );
 
-        const { code } = shell.exec(cmd);
-        if (code !== 0) {
-            _echoInstallErrorAndExit(code);
+        if (!_execAndExitIfErrored(cmd)) {
             return;
         }
 
@@ -96,14 +104,15 @@ require("./command-runner").run(async () => {
     };
 
     const _installDevAlias = () => {
+        const andCliDev = `${CLI_NAME}-dev`;
         echo.message(
-            `Configuring cli development '${CLI_NAME}-dev' bash alias...`
+            `Configuring cli development '${andCliDev}' bash alias...`
         );
         const pathToCli = upath.join(shell.pwd().toString(), ENTRYPOINT);
-        const developerAlias = `alias ${CLI_NAME}-dev='${pathToCli}'`;
+        const developerAlias = `alias ${andCliDev}='${pathToCli}'`;
 
         if (_bashFileContains(developerAlias)) {
-            echo.success(`${CLI_NAME}-dev bash alias already installed`);
+            echo.success(`${andCliDev} bash alias already installed`);
             echo.newLine();
             return;
         }
@@ -114,7 +123,7 @@ require("./command-runner").run(async () => {
         );
         _writeToBashFile(developerAlias);
 
-        echo.success(`Successfully installed ${CLI_NAME}-dev alias`);
+        echo.success(`Successfully installed ${andCliDev} alias`);
     };
 
     const _installLocalProjectGlobally = (binName) => {
@@ -123,9 +132,7 @@ require("./command-runner").run(async () => {
             `Installing current project as a global npm tool... (via ${cmd})`
         );
 
-        const { code } = shell.exec(cmd);
-        if (code !== 0) {
-            _echoInstallErrorAndExit(code);
+        if (!_execAndExitIfErrored(cmd)) {
             return;
         }
 

--- a/modules/command-registry.js
+++ b/modules/command-registry.js
@@ -409,7 +409,7 @@ const commandRegistry = {
      * @returns `this` for chaining
      */
     registerAliasesFromConfig(overrideIfRegistered = false) {
-        const { aliases } = packageConfig.getLocalConfigOrDefault();
+        const { aliases } = packageConfig.getLocalAndCliConfigOrDefault();
         const aliasKeys = Object.keys(aliases);
 
         if (CollectionUtils.isEmpty(aliasKeys)) {

--- a/modules/command-registry.test.js
+++ b/modules/command-registry.test.js
@@ -394,7 +394,7 @@ describe("commandRegistry", () => {
             // Arrange
             jest.spyOn(
                 packageConfig,
-                "getLocalConfigOrDefault"
+                "getLocalAndCliConfigOrDefault"
             ).mockImplementation(() => {
                 return { aliases: {} };
             });
@@ -414,7 +414,7 @@ describe("commandRegistry", () => {
                 program.command(command, description);
                 jest.spyOn(
                     packageConfig,
-                    "getLocalConfigOrDefault"
+                    "getLocalAndCliConfigOrDefault"
                 ).mockImplementation(() => {
                     return {
                         aliases: {
@@ -438,7 +438,7 @@ describe("commandRegistry", () => {
                 program.command(command, description);
                 jest.spyOn(
                     packageConfig,
-                    "getLocalConfigOrDefault"
+                    "getLocalAndCliConfigOrDefault"
                 ).mockImplementation(() => {
                     return {
                         aliases: {
@@ -462,7 +462,7 @@ describe("commandRegistry", () => {
                 const overrideIfRegistered = faker.random.boolean(); // This shouldn't matter
                 jest.spyOn(
                     packageConfig,
-                    "getLocalConfigOrDefault"
+                    "getLocalAndCliConfigOrDefault"
                 ).mockImplementation(() => {
                     return {
                         aliases: {

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -2,6 +2,9 @@
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
+/** Constant to represent the 'bin' folder or config section */
+module.exports.BIN = "bin";
+
 /** Constant to hold a reference to name of the CLI so we aren't hard-coding it multiple places */
 module.exports.CLI_NAME = "and-cli";
 

--- a/modules/package-config.js
+++ b/modules/package-config.js
@@ -2,7 +2,10 @@
 // #region Imports
 // -----------------------------------------------------------------------------------------
 
-const { CoreUtils } = require("andculturecode-javascript-core");
+const {
+    CoreUtils,
+    CollectionUtils,
+} = require("andculturecode-javascript-core");
 const { CLI_NAME, PACKAGE_JSON } = require("./constants");
 const finder = require("find-package-json");
 const upath = require("upath");
@@ -70,6 +73,26 @@ const packageConfig = {
         }
 
         return localPackageJson;
+    },
+
+    /**
+     * Returns the first binary name from the local package.json file. If no 'bin' section exists,
+     * or it contains no values, it returns `undefined`. If multiple keys exist, only the first will
+     * be returned.
+     */
+    getLocalBinName() {
+        const localPackageJson = this.getLocal();
+        if (localPackageJson == null || localPackageJson["bin"] == null) {
+            return undefined;
+        }
+
+        const bin = localPackageJson["bin"];
+        const keys = Object.keys(bin);
+        if (CollectionUtils.isEmpty(keys)) {
+            return undefined;
+        }
+
+        return keys[0];
     },
 
     /**

--- a/modules/package-config.js
+++ b/modules/package-config.js
@@ -6,7 +6,7 @@ const {
     CoreUtils,
     CollectionUtils,
 } = require("andculturecode-javascript-core");
-const { CLI_NAME, PACKAGE_JSON } = require("./constants");
+const { BIN, CLI_NAME, PACKAGE_JSON } = require("./constants");
 const finder = require("find-package-json");
 const upath = require("upath");
 
@@ -16,25 +16,40 @@ const upath = require("upath");
 // #region Constants
 // -----------------------------------------------------------------------------------------
 
-/**
- * Default object to be returned if the 'and-cli' section of the package.json is missing
- */
 const _defaultConfig = {
-    aliases: {},
+    [_sections.ALIASES]: {},
+};
+
+const _sections = {
+    ALIASES: "aliases",
 };
 
 // #endregion Constants
-
-// -----------------------------------------------------------------------------------------
-// #region Functions
-// -----------------------------------------------------------------------------------------
 
 /**
  * Module to wrap access to the package.json file. Any reading/transforming of data from that file
  * should live here.
  */
 const packageConfig = {
+    // -----------------------------------------------------------------------------------------
+    // #region Public Members
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * Default object to be returned if the 'and-cli' section of the package.json is missing
+     */
     DEFAULT_CONFIG: _defaultConfig,
+
+    /**
+     * Object to hold constants for each supported config under the 'and-cli' section
+     */
+    SECTIONS: _sections,
+
+    // #endregion Public Members
+
+    // -----------------------------------------------------------------------------------------
+    // #region Public Functions
+    // -----------------------------------------------------------------------------------------
 
     /**
      * Returns the package.json file for the base `and-cli` package.
@@ -82,11 +97,11 @@ const packageConfig = {
      */
     getLocalBinName() {
         const localPackageJson = this.getLocal();
-        if (localPackageJson == null || localPackageJson["bin"] == null) {
+        if (localPackageJson == null || localPackageJson[BIN] == null) {
             return undefined;
         }
 
-        const bin = localPackageJson["bin"];
+        const bin = localPackageJson[BIN];
         const keys = Object.keys(bin);
         if (CollectionUtils.isEmpty(keys)) {
             return undefined;
@@ -98,7 +113,7 @@ const packageConfig = {
     /**
      * Returns the 'and-cli' config section for the currently executing package, or a default object.
      */
-    getLocalConfigOrDefault() {
+    getLocalAndCliConfigOrDefault() {
         let packageJson = this.getLocal();
         if (packageJson[CLI_NAME] == null) {
             return _defaultConfig;
@@ -107,9 +122,9 @@ const packageConfig = {
         // Return the 'and-cli' section merged with the default config structure if certain properties are not set
         return CoreUtils.merge(packageJson[CLI_NAME], _defaultConfig);
     },
-};
 
-// #endregion Functions
+    // #endregion Public Functions
+};
 
 // -----------------------------------------------------------------------------------------
 // #region Exports

--- a/modules/package-config.js
+++ b/modules/package-config.js
@@ -16,12 +16,13 @@ const upath = require("upath");
 // #region Constants
 // -----------------------------------------------------------------------------------------
 
-const _defaultConfig = {
-    [_sections.ALIASES]: {},
+// Must be defined before _defaultConfig variable in scope
+const __sections = {
+    ALIASES: "aliases",
 };
 
-const _sections = {
-    ALIASES: "aliases",
+const _defaultConfig = {
+    [__sections.ALIASES]: {},
 };
 
 // #endregion Constants
@@ -43,7 +44,7 @@ const packageConfig = {
     /**
      * Object to hold constants for each supported config under the 'and-cli' section
      */
-    SECTIONS: _sections,
+    SECTIONS: __sections,
 
     // #endregion Public Members
 

--- a/modules/package-config.test.js
+++ b/modules/package-config.test.js
@@ -20,6 +20,14 @@ const testUtils = require("../tests/test-utils");
 // #endregion Imports
 
 // -----------------------------------------------------------------------------------------
+// #region Constants
+// -----------------------------------------------------------------------------------------
+
+const { ALIASES } = packageConfig.SECTIONS;
+
+// #endregion Constants
+
+// -----------------------------------------------------------------------------------------
 // #region Tests
 // -----------------------------------------------------------------------------------------
 
@@ -132,7 +140,7 @@ describe("packageConfig", () => {
     // -----------------------------------------------------------------------------------------
 
     describe("getLocalConfigOrDefault", () => {
-        test("given no 'and-cli' section exists, it returns the default config", () => {
+        test(`given no '${CLI_NAME}' section exists, it returns the default config`, () => {
             // Arrange
             const getLocalSpy = jest
                 .spyOn(packageConfig, "getLocal")
@@ -148,8 +156,8 @@ describe("packageConfig", () => {
             expect(result).toStrictEqual(packageConfig.DEFAULT_CONFIG);
         });
 
-        describe("given 'and-cli' section exists", () => {
-            test("given no 'aliases' section exists, it returns a default value for the 'aliases' section", () => {
+        describe(`given '${CLI_NAME}' section exists`, () => {
+            test(`given no '${ALIASES}' section exists, it returns a default value for the '${ALIASES}' section`, () => {
                 // Arrange
                 const getLocalSpy = jest
                     .spyOn(packageConfig, "getLocal")

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "jest-extended": "0.11.5",
         "nock": "12.0.3",
         "prettier": "1.19.1",
-        "pryjs": "1.0.3"
+        "pryjs": "1.0.3",
+        "rimraf": "3.0.2"
     },
     "engines": {
         "node": ">=8.0.0"
@@ -44,6 +45,7 @@
         "url": "git@github.com:AndcultureCode/AndcultureCode.Cli.git"
     },
     "scripts": {
+        "clean": "echo Removing leftover tmp directories && rimraf tmp*",
         "configure:git": "echo Ensuring git hooksPath is set to .githooks directory && git config core.hooksPath .githooks && chmod +x .githooks/*",
         "postpublish": "cross-env-shell \"git add -A && git commit -m \"$npm_package_version\" && git push origin main\"",
         "test": "jest",


### PR DESCRIPTION
Fixes #112 Installing plugins

Adds logic to the `install` command to automatically install the CLI globally if the `bin` section of the `package.json` has a key (always taking the first, if multiple found) that does not match `and-cli`. Some minor refactors to pull out each step of that command into a private function for readability & easier extraction to a module later on. 

I wanted to write some integration tests for this, but I ran into some issues managing temporary/home directories in the test suite. I'll do some further investigation and possibly follow up with later PR(s).

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
    - More test coverage can certainly be added once the `install` functions are broken out into a module
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
