### PR TITLE
Correcting incorrect usage of prompt, causing a runtime exception

### DIFF
--- a/and-cli-deploy-jenkins.js
+++ b/and-cli-deploy-jenkins.js
@@ -106,7 +106,7 @@ require("./command-runner").run(async () => {
             const configPath = jenkins.getConfigPath();
             const userPrompt = prompt.getPrompt();
 
-            await userPrompt.confirmOrExit(
+            await prompt.confirmOrExit(
                 "This operation will overwrite any existing configurations. Continue?"
             );
 


### PR DESCRIPTION
Correcting incorrect usage of prompt, causing a runtime exception
#128 

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [/] Documentation updated (readme, docs, comments, etc.)
-   [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
