### PR TITLE
Fix executable path construction for base commands in plugin projects

### DIFF
--- a/src/modules/command-registry.test.ts
+++ b/src/modules/command-registry.test.ts
@@ -547,11 +547,12 @@ describe("CommandRegistry", () => {
                     const { command, description } = faker.random.arrayElement(
                         CommandDefinitions
                     );
-                    // The expected file path should point to ./node_modules/and-cli/and-cli-{commandName}.js
+                    // The expected file path should point to the transpiled JS in the node_modules folder
                     const expectedFilePath = upath.join(
                         ".",
                         Constants.NODE_MODULES,
                         Constants.CLI_NAME,
+                        Constants.DIST,
                         `${Constants.CLI_NAME}-${command}.js`
                     );
                     CommandRegistry.initialize(true); // This is the important setup

--- a/src/modules/command-registry.ts
+++ b/src/modules/command-registry.ts
@@ -387,11 +387,12 @@ const _getAliasCommandDefinitions = (): CommandDefinition[] => {
 const _getExecutablePath = (commandName: string): string => {
     const filename = `${Constants.CLI_NAME}-${commandName}.js`;
     if (_isImportedModule != null && _isImportedModule) {
-        // Returns './node_modules/and-cli/and-cli-dotnet.js, for example
+        // Returns './node_modules/and-cli/dist/and-cli-dotnet.js', for example
         return upath.join(
             ".",
             Constants.NODE_MODULES,
             Constants.CLI_NAME,
+            Constants.DIST,
             filename
         );
     }


### PR DESCRIPTION
Fixes #138 Plugin project - path to base commands are not being properly constructed 

Update executable path for base commands registered by plugin cli projects to point to `dist/and-cli-<command>.js`

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
    - Tested using a branch off of my fork of the `AndcultureCode.Cli.PluginExample` project
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
