### PR TITLE
Fix dotnet-test integration tests related to dotnet core 3.1+ on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 version: "~> 1.0"
-
 env:
     global:
         - CI: true
-        - DOTNET_CLI_TELEMETRY_OPTOUT: 1
         - NODE_VERSION: 8.16.2
 jobs:
     include:
-        - name: "unit tests (Linux)"
-          os: linux
+        - stage: "unit tests"
           language: node
           node_js: $NODE_VERSION
           before_script:
@@ -17,53 +14,15 @@ jobs:
           script:
               - npm run test:unit
               - codecov --disable=gcov
-        - name: "integration tests (Linux)"
-          os: linux
-          dotnet: 3.1.403
+        - stage: "integration tests"
+          dotnet: 2.2.1
+          env:
+              - DOTNET_CLI_TELEMETRY_OPTOUT: 1
           language: csharp
           mono: none
           before_script:
               - nvm install $NODE_VERSION
               - nvm use $NODE_VERSION
-              - npm install
-          script:
-              - npm run test:integration
-        - name: "unit tests (Windows)"
-          os: windows
-          language: node
-          node_js: $NODE_VERSION
-          before_script:
-              - npm install
-              - npm install -g codecov
-          script:
-              - npm run test:unit
-              - codecov --disable=gcov
-        - name: "integration tests (Windows)"
-          os: windows
-          language: node
-          node_js: $NODE_VERSION
-          before_script:
-              - choco install dotnetcore-sdk --version 3.1.403
-              - npm install
-          script:
-              - npm run test:integration
-        - name: "unit tests (macOS)"
-          os: osx
-          language: node
-          node_js: $NODE_VERSION
-          before_script:
-              - npm install
-              - npm install -g codecov
-          script:
-              - npm run test:unit
-              - codecov --disable=gcov
-        - name: "integration tests (macOS)"
-          os: osx
-          language: node
-          node_js: $NODE_VERSION
-          before_script:
-              - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 3.1.403
-              - export PATH=~/.dotnet:$PATH
               - npm install
           script:
               - npm run test:integration
@@ -73,4 +32,4 @@ notifications:
         on_pull_requests: true
         on_success: always
         rooms:
-            - secure: wdda+ChsX3Z6dVXbiHxQan1bMknQMjTWlY42zdyZykL//VtwXmAZfuySwNt+3o6D/JVzr8zpUFxzWS050TFwU2HTKX0p14WhYdWWpqPuE+is1Hss6W7GtflHNzbZW2CJfi6/PcHqSCtShPQUkFAPl9OVtc56B/bC6jx5c4MvxPUIzrBP+XHttp2kJDOH0HVv3E09ogpYnu6+XDgZuMQQJrQKPy1vy1VblTY7QSzBTTJDthzy7tDdNwFxuMg5GavGGyNQ2XEGWNzkau0pG+z9KW2VrlTl7iXpgGWjjyBDVUOUq2jYx2MHLsxHnmVjHdQzlNsa5HZKjBUKLk17Y2whT1kbt0u4CCO26C/cnsOx8TI6vUkYVh/A6GtLRGO84RqxiV452vJv7jDnfYDjjz2Z974hDyQEbgkBZWJoVFqHYyRNInL9+se6ltbzvHrJdr/pm7bNsX5T84qskksNS/ovK1bftvahQFrIKJnysRHW/3S/BHbsNhT3iCYGt4OimH9OxAYPhT8D7WPeBgyOXxwiKzZijXuq2UZG+qvLTYwjUOQL/+Rr/BAw5JmYAJczZABrcY3vH1eWEpYBJFzh+ws2qosIaipM/tVhn9FpAYAfRPelo/Lz5zBlv+uWNpeKu77J+K610dH7t///KHLhgPAqsVF3PNyIn0u1n59mZt60k2k=
+            secure: wdda+ChsX3Z6dVXbiHxQan1bMknQMjTWlY42zdyZykL//VtwXmAZfuySwNt+3o6D/JVzr8zpUFxzWS050TFwU2HTKX0p14WhYdWWpqPuE+is1Hss6W7GtflHNzbZW2CJfi6/PcHqSCtShPQUkFAPl9OVtc56B/bC6jx5c4MvxPUIzrBP+XHttp2kJDOH0HVv3E09ogpYnu6+XDgZuMQQJrQKPy1vy1VblTY7QSzBTTJDthzy7tDdNwFxuMg5GavGGyNQ2XEGWNzkau0pG+z9KW2VrlTl7iXpgGWjjyBDVUOUq2jYx2MHLsxHnmVjHdQzlNsa5HZKjBUKLk17Y2whT1kbt0u4CCO26C/cnsOx8TI6vUkYVh/A6GtLRGO84RqxiV452vJv7jDnfYDjjz2Z974hDyQEbgkBZWJoVFqHYyRNInL9+se6ltbzvHrJdr/pm7bNsX5T84qskksNS/ovK1bftvahQFrIKJnysRHW/3S/BHbsNhT3iCYGt4OimH9OxAYPhT8D7WPeBgyOXxwiKzZijXuq2UZG+qvLTYwjUOQL/+Rr/BAw5JmYAJczZABrcY3vH1eWEpYBJFzh+ws2qosIaipM/tVhn9FpAYAfRPelo/Lz5zBlv+uWNpeKu77J+K610dH7t///KHLhgPAqsVF3PNyIn0u1n59mZt60k2k=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 version: "~> 1.0"
+
 env:
     global:
         - CI: true
+        - DOTNET_CLI_TELEMETRY_OPTOUT: 1
         - NODE_VERSION: 8.16.2
 jobs:
     include:
-        - stage: "unit tests"
+        - name: "unit tests (Linux)"
+          os: linux
           language: node
           node_js: $NODE_VERSION
           before_script:
@@ -14,15 +17,53 @@ jobs:
           script:
               - npm run test:unit
               - codecov --disable=gcov
-        - stage: "integration tests"
-          dotnet: 2.2.1
-          env:
-              - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+        - name: "integration tests (Linux)"
+          os: linux
+          dotnet: 3.1.403
           language: csharp
           mono: none
           before_script:
               - nvm install $NODE_VERSION
               - nvm use $NODE_VERSION
+              - npm install
+          script:
+              - npm run test:integration
+        - name: "unit tests (Windows)"
+          os: windows
+          language: node
+          node_js: $NODE_VERSION
+          before_script:
+              - npm install
+              - npm install -g codecov
+          script:
+              - npm run test:unit
+              - codecov --disable=gcov
+        - name: "integration tests (Windows)"
+          os: windows
+          language: node
+          node_js: $NODE_VERSION
+          before_script:
+              - choco install dotnetcore-sdk --version 3.1.403
+              - npm install
+          script:
+              - npm run test:integration
+        - name: "unit tests (macOS)"
+          os: osx
+          language: node
+          node_js: $NODE_VERSION
+          before_script:
+              - npm install
+              - npm install -g codecov
+          script:
+              - npm run test:unit
+              - codecov --disable=gcov
+        - name: "integration tests (macOS)"
+          os: osx
+          language: node
+          node_js: $NODE_VERSION
+          before_script:
+              - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 3.1.403
+              - export PATH=~/.dotnet:$PATH
               - npm install
           script:
               - npm run test:integration
@@ -32,4 +73,4 @@ notifications:
         on_pull_requests: true
         on_success: always
         rooms:
-            secure: wdda+ChsX3Z6dVXbiHxQan1bMknQMjTWlY42zdyZykL//VtwXmAZfuySwNt+3o6D/JVzr8zpUFxzWS050TFwU2HTKX0p14WhYdWWpqPuE+is1Hss6W7GtflHNzbZW2CJfi6/PcHqSCtShPQUkFAPl9OVtc56B/bC6jx5c4MvxPUIzrBP+XHttp2kJDOH0HVv3E09ogpYnu6+XDgZuMQQJrQKPy1vy1VblTY7QSzBTTJDthzy7tDdNwFxuMg5GavGGyNQ2XEGWNzkau0pG+z9KW2VrlTl7iXpgGWjjyBDVUOUq2jYx2MHLsxHnmVjHdQzlNsa5HZKjBUKLk17Y2whT1kbt0u4CCO26C/cnsOx8TI6vUkYVh/A6GtLRGO84RqxiV452vJv7jDnfYDjjz2Z974hDyQEbgkBZWJoVFqHYyRNInL9+se6ltbzvHrJdr/pm7bNsX5T84qskksNS/ovK1bftvahQFrIKJnysRHW/3S/BHbsNhT3iCYGt4OimH9OxAYPhT8D7WPeBgyOXxwiKzZijXuq2UZG+qvLTYwjUOQL/+Rr/BAw5JmYAJczZABrcY3vH1eWEpYBJFzh+ws2qosIaipM/tVhn9FpAYAfRPelo/Lz5zBlv+uWNpeKu77J+K610dH7t///KHLhgPAqsVF3PNyIn0u1n59mZt60k2k=
+            - secure: wdda+ChsX3Z6dVXbiHxQan1bMknQMjTWlY42zdyZykL//VtwXmAZfuySwNt+3o6D/JVzr8zpUFxzWS050TFwU2HTKX0p14WhYdWWpqPuE+is1Hss6W7GtflHNzbZW2CJfi6/PcHqSCtShPQUkFAPl9OVtc56B/bC6jx5c4MvxPUIzrBP+XHttp2kJDOH0HVv3E09ogpYnu6+XDgZuMQQJrQKPy1vy1VblTY7QSzBTTJDthzy7tDdNwFxuMg5GavGGyNQ2XEGWNzkau0pG+z9KW2VrlTl7iXpgGWjjyBDVUOUq2jYx2MHLsxHnmVjHdQzlNsa5HZKjBUKLk17Y2whT1kbt0u4CCO26C/cnsOx8TI6vUkYVh/A6GtLRGO84RqxiV452vJv7jDnfYDjjz2Z974hDyQEbgkBZWJoVFqHYyRNInL9+se6ltbzvHrJdr/pm7bNsX5T84qskksNS/ovK1bftvahQFrIKJnysRHW/3S/BHbsNhT3iCYGt4OimH9OxAYPhT8D7WPeBgyOXxwiKzZijXuq2UZG+qvLTYwjUOQL/+Rr/BAw5JmYAJczZABrcY3vH1eWEpYBJFzh+ws2qosIaipM/tVhn9FpAYAfRPelo/Lz5zBlv+uWNpeKu77J+K610dH7t///KHLhgPAqsVF3PNyIn0u1n59mZt60k2k=

--- a/src/modules/github.test.ts
+++ b/src/modules/github.test.ts
@@ -7,6 +7,8 @@ import nock from "nock";
 import { TestUtils } from "../tests/test-utils";
 import { Prompt } from "./prompt";
 import { Repository } from "../interfaces/repository";
+import { Factory } from "rosie";
+import { FactoryType } from "../tests/factories/factory-type";
 
 // -----------------------------------------------------------------------------------------
 // #region Tests
@@ -37,8 +39,8 @@ describe("Github", () => {
         owner: string,
         repoName: string,
         pullNumber: number
-    ) => {
-        return new RegExp(
+    ) =>
+        new RegExp(
             [
                 Github.apiRepositoriesRouteParam,
                 owner,
@@ -48,7 +50,7 @@ describe("Github", () => {
                 Github.apiReviewsRouteParam,
             ].join("/")
         );
-    };
+
     /**
      * Utility function for generating the /{owner}/repos API route
      */
@@ -68,12 +70,6 @@ describe("Github", () => {
             ].join("/")
         );
 
-    afterEach(() => {
-        // Clean all mocked API routes - some tests in here actually call the Github API, and will
-        // flake out depending on ordering.
-        nock.cleanAll();
-    });
-
     // #endregion Setup
 
     // -----------------------------------------------------------------------------------------
@@ -84,10 +80,9 @@ describe("Github", () => {
         test(`it calls addTopicToRepository for each ${Github.andcultureOrg} repo`, async () => {
             // Arrange
             const topic = TestUtils.randomWord();
-            const repos = [
-                { name: "AndcultureCode.Cli" },
-                { name: "AndcultureCode.CSharp.Core" },
-            ];
+            const repos = Factory.buildList(FactoryType.Repository, 2, {
+                name: `${Github.andcultureOrg}.${TestUtils.randomWord()}`,
+            });
 
             // Mock the API response for repositories
             nock(Github.apiRootUrl)
@@ -504,6 +499,17 @@ describe("Github", () => {
             const expectedUsername = "AndcultureCode";
             const expectedRepo = "AndcultureCode.Cli";
 
+            const mockRepo = Factory.build<Repository>(FactoryType.Repository, {
+                name: expectedRepo,
+                owner: { login: expectedUsername },
+            });
+
+            nock(Github.apiRootUrl)
+                .get(
+                    `/${Github.apiRepositoriesRouteParam}/${expectedUsername}/${expectedRepo}`
+                )
+                .reply(200, mockRepo);
+
             // Act
             const result = await Github.getRepo(expectedUsername, expectedRepo);
 
@@ -532,10 +538,13 @@ describe("Github", () => {
         test("given username, returns list of repositories", async () => {
             // Arrange
             const expected = "wintondeshong";
+            const repos = Factory.buildList(FactoryType.Repository, 2, {
+                url: `${faker.internet.url()}/${expected}`,
+            });
 
             nock(Github.apiRootUrl)
                 .get(getReposRoute(expected)) // make sure Github is properly passed username
-                .reply(200, [{ url: `https://someurl.com/${expected}` }]);
+                .reply(200, repos);
 
             // Act
             const results = await Github.repositories(expected);
@@ -552,10 +561,18 @@ describe("Github", () => {
             const username = "wintondeshong";
             const expected = Github.andcultureOrg;
             const unexpected = TestUtils.randomWord();
+            const repos = [
+                Factory.build<Repository>(FactoryType.Repository, {
+                    name: expected,
+                }),
+                Factory.build<Repository>(FactoryType.Repository, {
+                    name: unexpected,
+                }),
+            ];
 
             nock(Github.apiRootUrl)
                 .get(getReposRoute(username)) // make sure Github is properly passed username
-                .reply(200, [{ name: expected }, { name: unexpected }]);
+                .reply(200, repos);
 
             const filter = (repos: Repository[]) =>
                 repos.filter((r: Repository) => r.name.startsWith(expected));
@@ -579,10 +596,13 @@ describe("Github", () => {
         test(`given no username, returns list of main ${Github.andcultureOrg} repositories`, async () => {
             // Arrange
             const expected = Github.andcultureOrg;
+            const repos = Factory.buildList(FactoryType.Repository, 1, {
+                name: expected,
+            });
 
             nock(Github.apiRootUrl)
                 .get(getReposRoute(expected)) // make sure Github is properly passed username
-                .reply(200, [{ name: expected }]);
+                .reply(200, repos);
 
             // Act
             const results = await Github.repositoriesByAndculture();
@@ -597,10 +617,18 @@ describe("Github", () => {
             const username = "wintondeshong";
             const expected = Github.andcultureOrg;
             const unexpected = TestUtils.randomWord();
+            const repos = [
+                Factory.build<Repository>(FactoryType.Repository, {
+                    name: expected,
+                }),
+                Factory.build<Repository>(FactoryType.Repository, {
+                    name: unexpected,
+                }),
+            ];
 
             nock(Github.apiRootUrl)
                 .get(getReposRoute(username)) // make sure Github is properly passed username
-                .reply(200, [{ name: expected }, { name: unexpected }]);
+                .reply(200, repos);
 
             // Act
             const results = await Github.repositoriesByAndculture(username);
@@ -621,10 +649,13 @@ describe("Github", () => {
         test(`given no organization, returns list of main ${Github.andcultureOrg} repositories`, async () => {
             // Arrange
             const expected = Github.andcultureOrg;
+            const repos = Factory.buildList(FactoryType.Repository, 1, {
+                name: expected,
+            });
 
             nock(Github.apiRootUrl)
                 .get(getReposRoute(expected)) // make sure Github is properly passed username
-                .reply(200, [{ name: expected }]);
+                .reply(200, repos);
 
             // Act
             const results = await Github.repositoriesByOrganization();
@@ -637,10 +668,13 @@ describe("Github", () => {
         test(`given organization, returns list of main ${Github.andcultureOrg} repositories`, async () => {
             // Arrange
             const expected = TestUtils.randomWord();
+            const repos = Factory.buildList(FactoryType.Repository, 1, {
+                name: expected,
+            });
 
             nock(Github.apiRootUrl)
                 .get(getReposRoute(expected)) // make sure Github is properly passed username
-                .reply(200, [{ name: expected }]);
+                .reply(200, repos);
 
             // Act
             const results = await Github.repositoriesByOrganization(expected);
@@ -654,10 +688,18 @@ describe("Github", () => {
             // Arrange
             const expected = Github.andcultureOrg;
             const unexpected = TestUtils.randomWord();
+            const repos = [
+                Factory.build<Repository>(FactoryType.Repository, {
+                    name: expected,
+                }),
+                Factory.build<Repository>(FactoryType.Repository, {
+                    name: unexpected,
+                }),
+            ];
 
             nock(Github.apiRootUrl)
                 .get(getReposRoute(expected)) // make sure Github is properly passed username
-                .reply(200, [{ name: expected }, { name: unexpected }]);
+                .reply(200, repos);
 
             const filter = (repos: Repository[]) =>
                 repos.filter((r: Repository) => r.name.startsWith(expected));
@@ -684,10 +726,9 @@ describe("Github", () => {
         test(`it calls removeTopicFromRepository for each ${Github.andcultureOrg} repo`, async () => {
             // Arrange
             const topic = TestUtils.randomWord();
-            const repos = [
-                { name: "AndcultureCode.Cli" },
-                { name: "AndcultureCode.CSharp.Core" },
-            ];
+            const repos = Factory.buildList(FactoryType.Repository, 2, {
+                name: `${Github.andcultureOrg}.${TestUtils.randomWord()}`,
+            });
 
             // Mock the API response for repositories
             nock(Github.apiRootUrl)
@@ -791,7 +832,7 @@ describe("Github", () => {
                 const owner = TestUtils.randomWord();
                 const repoName = TestUtils.randomWord();
                 const existingTopics = [topic];
-                const expectedTopics: any = [];
+                const expectedTopics: string[] = [];
 
                 // We'll want to mock the token so that CI environments aren't left hanging
                 jest.spyOn(Github, "getToken").mockResolvedValue(

--- a/src/tests/factories/factory-type.ts
+++ b/src/tests/factories/factory-type.ts
@@ -3,6 +3,7 @@ import { FactoryType as AndcultureCodeFactoryType } from "andculturecode-javascr
 const FactoryType = {
     ...AndcultureCodeFactoryType,
     CommandDefinition: "CommandDefinition",
+    Repository: "Repository",
     WebpackRestoreOptions: "WebpackRestoreOptions",
 };
 

--- a/src/tests/factories/index.ts
+++ b/src/tests/factories/index.ts
@@ -1,2 +1,3 @@
 export { CommandDefinitionFactory } from "./command-definition-factory";
+export { RepositoryFactory } from "./repository-factory";
 export { WebpackRestoreOptionsFactory } from "./webpack-restore-options-factory";

--- a/src/tests/factories/repository-factory.ts
+++ b/src/tests/factories/repository-factory.ts
@@ -1,0 +1,27 @@
+import { Factory } from "rosie";
+import { FactoryType } from "./factory-type";
+import faker from "faker";
+import { Repository } from "../../interfaces/repository";
+import { TestUtils } from "../test-utils";
+
+// -------------------------------------------------------------------------------------------------
+// #region Factory
+// -------------------------------------------------------------------------------------------------
+
+const RepositoryFactory = Factory.define<Repository>(
+    FactoryType.Repository
+).attrs({
+    id: () => faker.random.number(),
+    name: () => TestUtils.randomWords().join("-"),
+    description: () => TestUtils.randomWords().join(" "),
+});
+
+// #endregion Factory
+
+// -------------------------------------------------------------------------------------------------
+// #region Exports
+// -------------------------------------------------------------------------------------------------
+
+export { RepositoryFactory };
+
+// #endregion Exports

--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -101,8 +101,6 @@ const TestUtils = {
      * @param {object} opts
      */
     executeCliCommand(command?: string, args: string[] = [], opts: any = {}) {
-        // Generate the absolute path of the main executable file (cli.js) based on the current
-        // file's directory.
         const cliEntrypointPath = upath.join(
             __dirname,
             "..",
@@ -219,17 +217,7 @@ const _createNodeProcess = (
     }
 
     return child_process.spawn(nodePath.toString(), args, {
-        env: Object.assign(
-            {
-                // Set the HOME directory to the current working directory. This should usually be a temp
-                // directory -- see TestUtils.createAndUseTmpDir()
-                HOME: shell.pwd().toString(),
-                NODE_ENV: "test",
-                // We need the PATH from the host to execute programs the same way a user would
-                PATH: process.env.PATH,
-            },
-            env
-        ),
+        env: Object.assign(process.env, env),
     });
 };
 


### PR DESCRIPTION
Fixes #107 dotnet-test command integration tests fail locally w/ .NET Core 3.1.x [Windows] 

- Merge all env variables from host with overrides vs. manual subset which breaks dotnet core 3.1 on Windows
    - Honestly not 100% sure what environment variable(s) might be breaking the dotnet package restore process, but it was reproducible before and after changing the way the env variables are setup for the spawned process
    
~Update Travis config to run on multiple operating systems to prevent cross-platform regressions~

~It looks like we may have been unintentionally using Travis [job "stages"](https://docs.travis-ci.com/user/build-stages/) which run sequentially. The current setup keeps each class of test (unit, integration) and operating system as separate jobs which can run in parallel. The Windows and macOS integration test jobs take the longest, but should be around 5-6 minutes.~
-  Update flaky github module test and add `RepositoryFactory`

---

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
