### PR TITLE
Add notify_start as dependency to build matrix job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: AndcultureCode.Cli
 on:
     push:
         branches: ["*"]
-    pull_request:
+    pull_request_target:
         branches: [main]
     workflow_dispatch:
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,7 @@ jobs:
             DOTNET_NOLOGO: true
             DOTNET_CLI_TELEMETRY_OPTOUT: true
         runs-on: ${{matrix.os}}
+        needs: [notify_start]
         strategy:
             matrix:
                 dotnet:


### PR DESCRIPTION
Add needs step to build to ensure slack notification starts before build jobs

Resolves #168 Github Actions: Update build job to depend on notify_start 


-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [-] Manually tested
-   [-] Automated tests are passing
-   [-] No _decreases_ in automated test coverage
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
