### PR TITLE
Additional tsconfig file for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "url": "git@github.com:AndcultureCode/AndcultureCode.Cli.git"
     },
     "scripts": {
-        "build": "tsc --pretty",
+        "build": "tsc --pretty --project tsconfig.dist.json",
         "clean": "echo Removing coverage, dist and leftover tmp directories && rimraf coverage && rimraf dist && rimraf tmp*",
         "configure:git": "echo Ensuring git hooksPath is set to .githooks directory && git config core.hooksPath .githooks && chmod +x .githooks/*",
         "format": "prettier --write \"src/**/*.ts\" --trailing-comma es5",

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
         "strict": true,
         "target": "es5"
     },
-    "exclude": ["node_modules", "**/*.test.ts"],
+    "exclude": ["node_modules"],
     "include": ["src"]
 }


### PR DESCRIPTION
Add distribution tsconfig extending the base version but excluding test files, update npm build script to point to dist config

Fixes #152 Additional tsconfig file for build - fix for jest-extended matchers excluded from IDE intellisense

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [-] Automated tests are passing
-   [-] No _decreases_ in automated test coverage
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
