### PR TITLE
Feature: Ability to recursively list commands/options

### DIFF
--- a/src/and-cli-ls.ts
+++ b/src/and-cli-ls.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { CommandRunner } from "./modules/command-runner";
+import { CommandDefinitions } from "./modules/command-definitions";
+import program from "commander";
+import { Options } from "./constants/options";
+import { ListCommands } from "./modules/list-commands";
+
+// -----------------------------------------------------------------------------------------
+// #region Constants
+// -----------------------------------------------------------------------------------------
+
+const { DEFAULT_OPTIONS } = ListCommands;
+const {
+    includeHelp: DEFAULT_INCLUDE_HELP,
+    indent: DEFAULT_INDENT,
+    prefix: DEFAULT_PREFIX,
+    skipCache: DEFAULT_SKIP_CACHE,
+    useColor: DEFAULT_USE_COLOR,
+} = DEFAULT_OPTIONS;
+
+// #endregion Constants
+
+CommandRunner.run(async () => {
+    // -----------------------------------------------------------------------------------------
+    // #region Entrypoint
+    // -----------------------------------------------------------------------------------------
+
+    program
+        .description(CommandDefinitions.ls.description)
+        .option(
+            "-i, --indent <indent>",
+            "Number of spaces to indent each level",
+            DEFAULT_INDENT.toString()
+        )
+        .option(
+            "--include-help",
+            `Include the help option for each command`,
+            DEFAULT_INCLUDE_HELP
+        )
+        .option(
+            "--no-color",
+            "Do not colorize command/options in output",
+            !DEFAULT_USE_COLOR
+        )
+        .option(
+            "-p, --prefix <prefix>",
+            "Prefix to display before each command/option",
+            DEFAULT_PREFIX
+        )
+        .option(
+            "--skip-cache",
+            "Skip attempting to read cached command list file",
+            DEFAULT_SKIP_CACHE
+        )
+        .parse(process.argv);
+
+    const { color, includeHelp, indent, prefix, skipCache } = program.opts();
+
+    ListCommands.run({
+        skipCache,
+        includeHelp,
+        indent: Number.parseInt(indent),
+        prefix,
+        useColor: color,
+    });
+
+    // #endregion Entrypoint
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,10 @@ export { AsyncReadlineInterface } from "./interfaces/async-readline-interface";
 export { CommandDefinition } from "./interfaces/command-definition";
 export { Issue } from "./interfaces/github/issue";
 export { Label } from "./interfaces/github/label";
+export { ListCommandsOptions } from "./interfaces/list-commands-options";
 export { Repository } from "./interfaces/github/repository";
 export { User } from "./interfaces/github/user";
+export { WebpackRestoreOptions } from "./interfaces/webpack-restore-options";
 
 // #endregion Interfaces
 

--- a/src/interfaces/command-definitions.ts
+++ b/src/interfaces/command-definitions.ts
@@ -30,9 +30,14 @@ interface CommandDefinitions extends Record<string, CommandDefinition> {
         };
     };
     install: CommandDefinition;
+    ls: CommandDefinition;
     migration: CommandDefinition;
     nuget: CommandDefinition;
-    restore: CommandDefinition;
+    restore: CommandDefinition & {
+        children: {
+            azureStorage: CommandDefinition;
+        };
+    };
     webpack: CommandDefinition;
     webpackTest: CommandDefinition;
     workspace: CommandDefinition;

--- a/src/interfaces/list-commands-options.ts
+++ b/src/interfaces/list-commands-options.ts
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------------------------
+// #region Interface
+// -----------------------------------------------------------------------------------------
+
+interface ListCommandsOptions {
+    /**
+     * Include the --help option for each command
+     */
+    includeHelp?: boolean;
+
+    /**
+     * Number of spaces to indent each level
+     */
+    indent?: number;
+
+    /**
+     * Prefix to display before each command/option
+     */
+    prefix?: string;
+
+    /**
+     * Skip attempting to read cached command list file
+     */
+    skipCache?: boolean;
+
+    /** Colorize command/options in output */
+    useColor?: boolean;
+}
+
+// #endregion Interface
+
+// -----------------------------------------------------------------------------------------
+// #region Exports
+// -----------------------------------------------------------------------------------------
+
+export { ListCommandsOptions };
+
+// #endregion Exports

--- a/src/modules/command-definitions.ts
+++ b/src/modules/command-definitions.ts
@@ -70,6 +70,10 @@ const CommandDefinitions: BaseCommandDefinitions = {
         description:
             "Collection of commands related to installation and configuration of the and-cli",
     },
+    ls: {
+        command: "ls",
+        description: "List all commands/options",
+    },
     migration: {
         command: "migration",
         description: "Run commands to manage Entity Framework migrations",
@@ -82,6 +86,12 @@ const CommandDefinitions: BaseCommandDefinitions = {
         command: "restore",
         description:
             "Restores application data assets for various application types",
+        children: {
+            azureStorage: {
+                command: "azure-storage",
+                description: "Restore application assets in Azure Storage",
+            },
+        },
     },
     webpack: {
         command: "webpack",

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -12,6 +12,9 @@ const Constants = {
     /** Constant to represent the 'bin' directory or config section */
     BIN: "bin",
 
+    /** Constant to represent the directory for and-cli related configuration files */
+    CLI_CONFIG_DIR: ".and-cli",
+
     /** Constant to hold a reference to name of the CLI so we aren't hard-coding it multiple places */
     CLI_NAME: "and-cli",
 

--- a/src/modules/file.test.ts
+++ b/src/modules/file.test.ts
@@ -1,0 +1,42 @@
+import { TestUtils } from "../tests/test-utils";
+import { File } from "./file";
+
+describe("File", () => {
+    // -----------------------------------------------------------------------------------------
+    // #region exists
+    // -----------------------------------------------------------------------------------------
+
+    describe("exists", () => {
+        test("given no file matching expression exists, returns false", () => {
+            // Arrange
+            const fileFirstSpy = jest
+                .spyOn(File, "first")
+                .mockReturnValue(undefined as any);
+            const fileExpression = TestUtils.randomPath();
+
+            // Act
+            const result = File.exists(fileExpression);
+
+            // Assert
+            expect(result).toBeFalse();
+            expect(fileFirstSpy).toHaveBeenCalled();
+        });
+
+        test("given file matching expression exists, returns true", () => {
+            // Arrange
+            const fileExpression = TestUtils.randomPath();
+            const fileFirstSpy = jest
+                .spyOn(File, "first")
+                .mockReturnValue(fileExpression);
+
+            // Act
+            const result = File.exists(fileExpression);
+
+            // Assert
+            expect(result).toBeTrue();
+            expect(fileFirstSpy).toHaveBeenCalled();
+        });
+    });
+
+    // #endregion exists
+});

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -34,7 +34,7 @@ const File = {
 
     /**
      * Deletes the file provided it exists
-     * @param {string} file Relative or absolute path to file
+     * @param file Relative or absolute path to file
      */
     deleteIfExists(file: string) {
         if (!fs.existsSync(file)) {
@@ -47,8 +47,14 @@ const File = {
     },
 
     /**
+     * Returns whether or not a file matching the given expression exists
+     */
+    exists(fileExpression: string): boolean {
+        return this.first(fileExpression) != null;
+    },
+
+    /**
      * Returns the first match of the provided file expression
-     * @param {string} fileExpression
      */
     first(fileExpression: string) {
         shell.config.silent = true;

--- a/src/modules/list-commands.ts
+++ b/src/modules/list-commands.ts
@@ -1,0 +1,308 @@
+import { CollectionUtils, StringUtils } from "andculturecode-javascript-core";
+import { Options } from "../constants/options";
+import { CommandDefinitionUtils } from "../utilities/command-definition-utils";
+import { Constants } from "./constants";
+import { Echo } from "./echo";
+import { Formatters } from "./formatters";
+import upath from "upath";
+import os from "os";
+import shell from "shelljs";
+import fs from "fs";
+import { File } from "./file";
+import { ListCommandsOptions } from "../interfaces/list-commands-options";
+import { CommandDefinitions } from "./command-definitions";
+
+// -----------------------------------------------------------------------------------------
+// #region Interfaces
+// -----------------------------------------------------------------------------------------
+
+/**
+ * DTO for parsing & storing command/option info from commander's output
+ */
+interface ParsedCommandDto {
+    command: string;
+    options: string[];
+    parent: string | null;
+}
+
+// #endregion Interfaces
+
+// -----------------------------------------------------------------------------------------
+// #region Constants
+// -----------------------------------------------------------------------------------------
+
+const { CLI_CONFIG_DIR, DIST, ENTRYPOINT } = Constants;
+const { difference, hasValues } = CollectionUtils;
+const { shortFlag: helpFlag } = Options.Help;
+const CACHE_FILENAME = "commands.json";
+const CACHE_PATH = upath.join(os.homedir(), CLI_CONFIG_DIR, CACHE_FILENAME);
+const COMMANDS_START_STRING = "Commands:";
+const COMMANDS_END_STRING = "help [command]";
+const DEFAULT_INDENT = 4;
+const DEFAULT_OPTIONS: Required<ListCommandsOptions> = {
+    includeHelp: false,
+    indent: DEFAULT_INDENT,
+    useColor: true,
+    prefix: "- [ ] ",
+    skipCache: false,
+};
+const OPTIONS_START_STRING = "Options:";
+const OPTIONS_END_STRING = Options.Help.toString();
+const PARENT_COMMANDS = CommandDefinitionUtils.getNames();
+
+// #endregion Constants
+
+// -----------------------------------------------------------------------------------------
+// #region Variables
+// -----------------------------------------------------------------------------------------
+
+let _dtos: ParsedCommandDto[] = [];
+let _options: Required<ListCommandsOptions> = { ...DEFAULT_OPTIONS };
+
+// #endregion Variables
+
+// -----------------------------------------------------------------------------------------
+// #region Public Functions
+// -----------------------------------------------------------------------------------------
+
+const ListCommands = {
+    DEFAULT_OPTIONS,
+    cmd(command: string): string {
+        const cliEntrypoint = upath.join(".", DIST, ENTRYPOINT);
+        return `node ${cliEntrypoint} ${command} ${helpFlag}`;
+    },
+    description(): string {
+        return CommandDefinitions.ls.description;
+    },
+    diffParentCommands(): boolean {
+        const cachedParentCommands = _getParentCommandsOrDefault(_dtos).map(
+            (dto) => dto.command
+        );
+
+        return (
+            hasValues(difference(PARENT_COMMANDS, cachedParentCommands)) ||
+            hasValues(difference(cachedParentCommands, PARENT_COMMANDS))
+        );
+    },
+    parse(): void {
+        PARENT_COMMANDS.forEach(_parseChildrenAndOptions);
+    },
+    parseOrReadCache(): void {
+        if (_options.skipCache) {
+            Echo.message("Skipping cache if it exists...");
+            this.parse();
+            return;
+        }
+
+        this.readCachedFile();
+        const parentCommandsDiffer = this.diffParentCommands();
+        if (hasValues(_dtos) && !parentCommandsDiffer) {
+            return;
+        }
+
+        if (hasValues(_dtos) && parentCommandsDiffer) {
+            Echo.message(
+                "Detected changes in parent commands that are not yet saved to the cache file - rebuilding."
+            );
+        }
+
+        this.resetCache();
+        this.parse();
+    },
+    print(dtos: ParsedCommandDto[], indent: number = 0): void {
+        // Ensure we start printing from the parent commands first so they appear in order
+        const commandsSortedByParents = _getParentCommandsOrDefault(dtos);
+
+        commandsSortedByParents.forEach((command) =>
+            this.printCommand(command, indent)
+        );
+    },
+    printCommand(dto: ParsedCommandDto, indent: number): void {
+        const commandMessage = _options.useColor
+            ? Formatters.green(dto.command)
+            : dto.command;
+        _echoFormatted(commandMessage, indent);
+
+        this.printOptions(dto, indent + _options.indent);
+
+        const children = _getChildren(dto);
+        this.print(children, indent + _options.indent * 2);
+    },
+    printOption(option: string, indent: number): void {
+        const optionMessage = _options.useColor
+            ? Formatters.yellow(option)
+            : option;
+        _echoFormatted(optionMessage, indent);
+    },
+    printOptions(dto: ParsedCommandDto, indent: number): void {
+        dto.options.forEach((option: string) =>
+            this.printOption(option, indent)
+        );
+    },
+    readCachedFile(): void {
+        if (!File.exists(CACHE_PATH)) {
+            this.resetCache();
+            Echo.message("No cached file found, building from scratch.");
+            return;
+        }
+
+        Echo.message("Found command list cache, attempting to read...");
+        try {
+            const file = fs.readFileSync(CACHE_PATH);
+            _dtos = JSON.parse(file.toString());
+        } catch (error) {
+            this.resetCache();
+            Echo.error(
+                `There was an error attempting to read or deserialize the file at ${CACHE_PATH} - ${error}`
+            );
+        }
+    },
+    resetCache(): void {
+        this.setOptions({ skipCache: true });
+        _dtos = [];
+    },
+    run(options: ListCommandsOptions): void {
+        this.setOptions(options);
+
+        this.parseOrReadCache();
+        this.print(_dtos);
+
+        this.saveCachedFile();
+    },
+    saveCachedFile(): void {
+        Echo.message(`Writing command list to cached file at ${CACHE_PATH}...`);
+        try {
+            shell.mkdir("-p", upath.dirname(CACHE_PATH));
+            shell.touch(CACHE_PATH);
+            fs.writeFileSync(CACHE_PATH, JSON.stringify(_dtos, undefined, 4));
+        } catch (error) {
+            Echo.error(
+                `There was an error writing to ${CACHE_PATH} - ${error}`
+            );
+            shell.exit(1);
+        }
+
+        Echo.success("Cached file successfully updated.");
+    },
+    setOptions(updated: Partial<ListCommandsOptions>): void {
+        _options = { ...DEFAULT_OPTIONS, ..._options, ...updated };
+    },
+};
+
+// #endregion Public Functions
+
+// -----------------------------------------------------------------------------------------
+// #region Private Functions
+// -----------------------------------------------------------------------------------------
+
+const _addOrUpdateDto = (updatedDto: ParsedCommandDto) => {
+    const findByCommand = (existingDto: ParsedCommandDto) =>
+        existingDto.command === updatedDto.command;
+    const existing = _dtos.find(findByCommand) ?? {};
+    _dtos = _dtos.filter(
+        (existing: ParsedCommandDto) => !findByCommand(existing)
+    );
+    _dtos.push({
+        ...existing,
+        ...updatedDto,
+    });
+};
+
+/**
+ * Constructs a dto with the proper parent/child relationship, taking into account nesting
+ */
+const _buildDto = (
+    fullCommand: string,
+    options: string[]
+): ParsedCommandDto => {
+    const commands = fullCommand.split(" ");
+    const hasNestedCommands = commands.length > 1;
+    // Remove the last space-separated string if present as it should be the deepest child
+    const command = hasNestedCommands ? commands.pop()! : fullCommand;
+    // If there are nested commands, pop off the closest parent from the end of the string (supports nesting of any depth)
+    const parent = hasNestedCommands ? commands.pop()! : null;
+
+    return {
+        command,
+        options,
+        parent,
+    };
+};
+
+/**
+ * Splits and filters output by new lines that match the starting & ending pattern to retrieve options
+ * or commands
+ */
+const _parseOutputByRange = (
+    output: string,
+    startPattern: string,
+    endPattern: string
+): string[] => {
+    let lines = output.split("\n");
+    const startIndex = lines.findIndex((line) => line.includes(startPattern));
+    const endIndex = lines.findIndex((line) => line.includes(endPattern));
+
+    lines = lines
+        .slice(startIndex + 1, endIndex + 1)
+        // Commands and options both start with two spaces in the command help output
+        .map((line) => line.split("  ")[1])
+        .filter(
+            // Some additional sanitization - empty lines obviously have no option or command in them
+            // and lines with tabs in them are more than likely custom command/option descriptions
+            (line) => StringUtils.hasValue(line) && !line.includes("\t")
+        );
+
+    if (!_options.includeHelp) {
+        lines = lines.filter(
+            (line) =>
+                line !== OPTIONS_END_STRING && line !== COMMANDS_END_STRING
+        );
+    }
+
+    return lines;
+};
+
+const _echoFormatted = (value: string, indent: number = 0) =>
+    Echo.message(`${" ".repeat(indent)}${_options.prefix}${value}`, false);
+
+const _getChildren = (parent: ParsedCommandDto): ParsedCommandDto[] =>
+    _dtos.filter((child: ParsedCommandDto) => child.parent === parent.command);
+
+const _getParentCommandsOrDefault = (commands: ParsedCommandDto[]) => {
+    const parents = commands.filter((command) => command.parent == null);
+    if (hasValues(parents)) {
+        return parents;
+    }
+
+    return commands;
+};
+
+const _parseChildrenAndOptions = (command: string) => {
+    const { stdout } = shell.exec(ListCommands.cmd(command), { silent: true });
+
+    const children = _parseChildren(stdout);
+    children.forEach((child: string) => {
+        // Recursively parse children/options
+        _parseChildrenAndOptions(`${command} ${child}`);
+    });
+
+    const options = _parseOptions(stdout);
+    const dto = _buildDto(command, options);
+    _addOrUpdateDto(dto);
+};
+
+const _parseChildren = (output: string) =>
+    _parseOutputByRange(output, COMMANDS_START_STRING, COMMANDS_END_STRING);
+
+const _parseOptions = (output: string) =>
+    _parseOutputByRange(output, OPTIONS_START_STRING, OPTIONS_END_STRING);
+
+// #endregion Private Functions
+
+// -----------------------------------------------------------------------------------------
+// #region Exports
+// -----------------------------------------------------------------------------------------
+
+export { ListCommands };
+
+// #endregion Exports


### PR DESCRIPTION
Fixes #132 Utility command for recursively listing commands & options 

Loops over all parent command definitions from the command definitions module, and recursively calls the CLI for each nested command to parse options. Stores the dtos in a flat list and reconstructs the tree hierarchy for printing.

Uses a cache file to speed up consecutive runs of the `ls` command unless intentionally skipped (or, there's no cache file, error reading, mismatched parent commands)

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [-] No _decreases_ in automated test coverage
    - Probably a small dip in coverage. Since this is primarily meant to be used for debugging/developer use, I'm not sure tests are absolutely necessary right now.
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
