### PR TITLE
Support/list command only shows parents and no options

### DIFF
--- a/src/modules/command-registry.ts
+++ b/src/modules/command-registry.ts
@@ -47,12 +47,19 @@ let _cachedConfig: CommandRegistryConfiguration = {};
 
 // #endregion Variables
 
-// -----------------------------------------------------------------------------------------
-// #region Public Functions
-// -----------------------------------------------------------------------------------------
-
 const CommandRegistry = {
+    // -----------------------------------------------------------------------------------------
+    // #region Public Members
+    // -----------------------------------------------------------------------------------------
+
     ALIAS_PREFIX,
+
+    // #endregion Public Members
+
+    // -----------------------------------------------------------------------------------------
+    // #region Public Functions
+    // -----------------------------------------------------------------------------------------
+
     /**
      * Clears out all command registered with the program.
      *
@@ -315,9 +322,9 @@ const CommandRegistry = {
         CommandUtils.remove(name);
         return this;
     },
-};
 
-// #endregion Public Functions
+    // #endregion Public Functions
+};
 
 // -----------------------------------------------------------------------------------------
 // #region Private Functions

--- a/src/modules/command-registry.ts
+++ b/src/modules/command-registry.ts
@@ -52,6 +52,7 @@ let _cachedConfig: CommandRegistryConfiguration = {};
 // -----------------------------------------------------------------------------------------
 
 const CommandRegistry = {
+    ALIAS_PREFIX,
     /**
      * Clears out all command registered with the program.
      *

--- a/src/modules/list-commands.ts
+++ b/src/modules/list-commands.ts
@@ -262,8 +262,12 @@ const _execCliHelp = (command?: string): string | never => {
     Echo.message(`Running ${coloredHelpCommand} for commands and options...`);
 
     if (code !== 0 || StringUtils.hasValue(stderr)) {
-        const coloredError = Formatters.red(stderr);
-        Echo.error(`Failed to run ${coloredHelpCommand}:\n\n${coloredError}`);
+        const coloredError = Formatters.red(
+            StringUtils.hasValue(stderr)
+                ? `\n\n${stderr}`
+                : `exited with code ${code}`
+        );
+        Echo.error(`Failed to run ${coloredHelpCommand}: ${coloredError}`);
         shell.exit(1);
     }
 

--- a/src/modules/list-commands.ts
+++ b/src/modules/list-commands.ts
@@ -34,7 +34,8 @@ interface ParsedCommandDto {
 
 const { CLI_NAME, CLI_CONFIG_DIR } = Constants;
 const { shortFlag: helpFlag } = Options.Help;
-const CACHE_FILENAME = "commands.json";
+const BIN_NAME = PackageConfig.getLocalBinName() ?? CLI_NAME;
+const CACHE_FILENAME = `commands.${BIN_NAME}.json`;
 const CACHE_PATH = upath.join(os.homedir(), CLI_CONFIG_DIR, CACHE_FILENAME);
 const COMMANDS_START_STRING = "Commands:";
 const COMMANDS_END_STRING = "help [command]";
@@ -68,12 +69,11 @@ let _options: Required<ListCommandsOptions> = { ...DEFAULT_OPTIONS };
 const ListCommands = {
     DEFAULT_OPTIONS,
     cmd(command?: string): string {
-        const binName = PackageConfig.getLocalBinName() ?? CLI_NAME;
         if (StringUtils.isEmpty(command)) {
-            return `${binName} ${helpFlag}`;
+            return `${BIN_NAME} ${helpFlag}`;
         }
 
-        return `${binName} ${command} ${helpFlag}`;
+        return `${BIN_NAME} ${command} ${helpFlag}`;
     },
     description(): string {
         return CommandDefinitions.list.description;


### PR DESCRIPTION
Fixes #199 List command only shows parents and no options

Removes some of the 'parent' command diffing logic, opting to get the initial list of commands from the CLI itself. Along with calling the CLI via its bin name in the package.json file, this allows the command to be be used with plugin CLIs as an added bonus

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
