### PR TITLE
Remove node version of codecov in favor of Github Action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,12 +78,13 @@ jobs:
             - name: npm install
               run: |
                   npm install
-                  npm install -g codecov
 
             - name: Unit tests
               run: |
                   npm run test:unit
-                  codecov --disable=gcov
+
+            - name: Upload to codecov
+              uses: codecov/codecov-action@v1
 
             - name: Setup .NET Core SDK ${{matrix.dotnet}}
               uses: actions/setup-dotnet@v1.7.2


### PR DESCRIPTION
Fixes #191 Codecov is not uploading/commenting with coverage report 

Verified this works on my fork: https://github.com/brandongregoryscott/AndcultureCode.Cli/pull/4

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
