### PR TITLE
Skip dev alias if exists

### DIFF
--- a/src/and-cli-install.ts
+++ b/src/and-cli-install.ts
@@ -9,9 +9,10 @@ import { Formatters } from "./modules/formatters";
 import { Js } from "./modules/js";
 import { PackageConfig } from "./modules/package-config";
 import program from "commander";
-import shell from "shelljs";
+import shell, { ShellString } from "shelljs";
 import upath from "upath";
 import { CommandRunner } from "./modules/command-runner";
+import { OptionStringBuilder } from "./utilities/option-string-builder";
 
 CommandRunner.run(async () => {
     // -----------------------------------------------------------------------------------------
@@ -19,6 +20,7 @@ CommandRunner.run(async () => {
     // -----------------------------------------------------------------------------------------
 
     const { CLI_NAME, ENTRYPOINT } = Constants;
+    const CLEAR_OPTION = new OptionStringBuilder("clear", "c");
 
     // #endregion Constants
 
@@ -63,6 +65,9 @@ CommandRunner.run(async () => {
     // #region Private Functions
     // -----------------------------------------------------------------------------------------
 
+    const _appendBashFile = (text: string) =>
+        shell.echo(text).toEnd(File.bashFile());
+
     const _bashFileContains = (text: string): boolean =>
         StringUtils.hasValue(_grepBashFile(text));
 
@@ -83,6 +88,9 @@ CommandRunner.run(async () => {
 
     const _grepBashFile = (text: string): string =>
         shell.cat(File.bashFile()).grep(text).stdout;
+
+    const _grepBashFileWithoutAliases = (): ShellString =>
+        shell.cat(File.bashFile()).grep("-v", CLI_NAME);
 
     const _installAndCliGlobally = (): void => {
         const cmd = install.cmd(CLI_NAME);
@@ -125,11 +133,11 @@ CommandRunner.run(async () => {
             return;
         }
 
-        _writeToBashFile("");
-        _writeToBashFile(
+        _appendBashFile("");
+        _appendBashFile(
             `# ${CLI_NAME} global development alias pointing to your fork of the repository`
         );
-        _writeToBashFile(developerAlias);
+        _appendBashFile(developerAlias);
 
         Echo.success(`Successfully installed ${andCliDev} alias`);
     };
@@ -165,16 +173,13 @@ CommandRunner.run(async () => {
             return;
         }
 
-        _writeToBashFile("");
-        _writeToBashFile(`# ${CLI_NAME} project-level alias`);
-        _writeToBashFile(projectAlias);
+        _appendBashFile("");
+        _appendBashFile(`# ${CLI_NAME} project-level alias`);
+        _appendBashFile(projectAlias);
 
         Echo.success(`Successfully installed ${CLI_NAME} bash alias`);
         Echo.newLine();
     };
-
-    const _writeToBashFile = (text: string) =>
-        shell.echo(text).toEnd(File.bashFile());
 
     // #endregion Private Functions
 
@@ -185,7 +190,18 @@ CommandRunner.run(async () => {
     program
         .usage("option(s)")
         .description(CommandDefinitions.install.description)
+        .option(
+            CLEAR_OPTION.toString(),
+            `Clear any existing aliases in ${File.bashFile()}`
+        )
         .parse(process.argv);
+
+    const { clear } = program.opts();
+    if (clear === true) {
+        Echo.message(`Clearing aliases from ${File.bashFile()}...`);
+        _grepBashFileWithoutAliases().to(File.bashFile());
+        return;
+    }
 
     // If no options are passed in, performs installation steps
     if (Js.hasNoArguments()) {

--- a/src/and-cli-install.ts
+++ b/src/and-cli-install.ts
@@ -63,11 +63,8 @@ CommandRunner.run(async () => {
     // #region Private Functions
     // -----------------------------------------------------------------------------------------
 
-    const _bashFileContains = (text: string): boolean => {
-        return StringUtils.hasValue(
-            shell.cat(File.bashFile()).grep(text).stdout
-        );
-    };
+    const _bashFileContains = (text: string): boolean =>
+        StringUtils.hasValue(_grepBashFile(text));
 
     const _echoInstallErrorAndExit = (code: number): never => {
         Echo.error(`There was an error installing the package: ${code}`);
@@ -83,6 +80,9 @@ CommandRunner.run(async () => {
 
         return true;
     };
+
+    const _grepBashFile = (text: string): string =>
+        shell.cat(File.bashFile()).grep(text).stdout;
 
     const _installAndCliGlobally = (): void => {
         const cmd = install.cmd(CLI_NAME);
@@ -113,6 +113,15 @@ CommandRunner.run(async () => {
         if (_bashFileContains(developerAlias)) {
             Echo.success(`${andCliDev} bash alias already installed`);
             Echo.newLine();
+            return;
+        }
+
+        if (_bashFileContains(andCliDev)) {
+            Echo.warn(`${andCliDev} bash alias exists for different directory`);
+            Echo.message(`Expected: ${Formatters.purple(developerAlias)}`);
+            Echo.message(
+                `Found:    ${Formatters.yellow(_grepBashFile(andCliDev))}`
+            );
             return;
         }
 


### PR DESCRIPTION
Resolves #136 Install command: Skip dev alias if already exists

Adds a safeguard to short-circuit the dev alias installation if `and-cli-dev` appears in the file (previously it was matching on the entire alias/path, which may be different depending on where the command is run from). It outputs the different path for reference.

Additionally, added a `--clear` flag which will remove any lines in the bash file that contain `and-cli`. Wanted an easy way to reset aliases in the bash file in the event the consumer has some really jacked up aliases that they want to reset. 


-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [-] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
