### PR TITLE
Update Github Actions workflow to properly parse dotnet version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: AndcultureCode.Cli
+name: build
 
 on:
     push:
@@ -32,15 +32,13 @@ jobs:
         if: always()
         strategy:
             matrix:
-                os:
-                    - windows-latest
-                dotnet:
-                    - 3.1
-                node:
-                    - 8.16.2
-                allowed-to-fail:
-                    - false
                 include:
+                    - {
+                          os: windows-latest,
+                          dotnet: 3.1,
+                          node: 8.16.2,
+                          allowed-to-fail: false,
+                      }
                     - {
                           os: macos-latest,
                           dotnet: 3.1,
@@ -94,7 +92,7 @@ jobs:
             - name: Force .NET Core ${{matrix.dotnet}} via global.json
               run: |
                   echo This step is only needed for macOS currently - see https://github.com/actions/setup-dotnet/issues/157
-                  DOTNET_VERSION=`ls ~/.dotnet/sdk/ | grep ${{matrix.dotnet}} | sort -r | head -1`
+                  DOTNET_VERSION=`ls ~/.dotnet/sdk/ | grep --fixed-strings ${{matrix.dotnet}} | sort -r | head -1`
                   echo Found $DOTNET_VERSION matching ${{matrix.dotnet}} in ~/.dotnet/sdk/
                   dotnet new globaljson --sdk-version "$DOTNET_VERSION"
               if: runner.os == 'macOS'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # AndcultureCode.Cli
 
-![build status](https://github.com/AndcultureCode/AndcultureCode.Cli/actions/workflows/main.yaml/badge.svg)
-[![codecov](https://codecov.io/gh/AndcultureCode/AndcultureCode.Cli/branch/master/graph/badge.svg)](https://codecov.io/gh/AndcultureCode/AndcultureCode.Cli)
+![build status](https://github.com/AndcultureCode/AndcultureCode.Cli/actions/workflows/build.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/AndcultureCode/AndcultureCode.Cli/branch/main/graph/badge.svg)](https://codecov.io/gh/AndcultureCode/AndcultureCode.Cli)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 `and-cli` command-line tool to manage the development of software applications.


### PR DESCRIPTION
Fixes #207 macOS CI Integration tests running .NET 5 instead of 3.1 

Additionally, renamed workflow file/name to more conventionally represent its purpose vs. the repo it is in. If we ever add more actions, ie `publish`, it'll make more sense in terms of naming.

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
    - https://github.com/brandongregoryscott/AndcultureCode.Cli/runs/2965839307
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
